### PR TITLE
Changes to infantry prep

### DIFF
--- a/html/changelogs/mocha-PR-28.yml
+++ b/html/changelogs/mocha-PR-28.yml
@@ -1,0 +1,13 @@
+author: Moca
+
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added new Recon hardsuits to infantry prep."
+  - rscadd: "Added two doors, respectively SL and CT"
+  - tweak: "Fixed the two tiles in space, also in infantry prep"

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -108,7 +108,7 @@
 /obj/machinery/door/window/southright{
 	dir = 1;
 	name = "Recon Leader";
-	req_access = list(infcom)
+	req_access = list(ACCESS_INFCOM)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/infantry/infcom)
@@ -6012,6 +6012,21 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"mW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Recon Technician";
+	req_access = list(ACCESS_INFTECH)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/infantry/inftech)
 "mX" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/structure/railing/mapped{
@@ -10525,21 +10540,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
-/area/infantry/inftech)
-"wC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Recon Technician";
-	req_access = list(inftech)
-	},
 /turf/simulated/floor/tiled/dark,
 /area/infantry/inftech)
 "wD" = (
@@ -31626,7 +31626,7 @@ IJ
 IJ
 IJ
 Yt
-wC
+mW
 Rh
 ET
 ME

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -107,8 +107,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/window/southright{
 	dir = 1;
-	name = "Recon Leader";
-	req_access = list(ACCESS_INFCOM)
+	name = "Recon Technician"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/infantry/infcom)
@@ -6012,21 +6011,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"mW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Recon Technician";
-	req_access = list(ACCESS_INFTECH)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/infantry/inftech)
 "mX" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/structure/railing/mapped{
@@ -13349,6 +13333,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
+"Go" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Recon Technician"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/infantry/inftech)
 "Gr" = (
 /obj/structure/table/standard,
 /obj/random/tool,
@@ -31626,7 +31624,7 @@ IJ
 IJ
 IJ
 Yt
-mW
+Go
 Rh
 ET
 ME

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -105,6 +105,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Recon Leader";
+	req_access = list(infcom)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/infantry/infcom)
 "al" = (
@@ -10522,6 +10527,21 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark,
 /area/infantry/inftech)
+"wC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Recon Technician";
+	req_access = list(inftech)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/infantry/inftech)
 "wD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable{
@@ -10847,7 +10867,6 @@
 /area/maintenance/fifthdeck/fore)
 "xR" = (
 /obj/structure/closet/secure_closet/infantry,
-/obj/item/weapon/rig/military/infantry,
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
@@ -10856,6 +10875,7 @@
 /obj/item/device/radio,
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/rig/recon/infantry,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
 "xS" = (
@@ -16982,7 +17002,6 @@
 	health = 1e+006
 	},
 /obj/structure/closet/secure_closet/inftech,
-/obj/item/weapon/rig/military/infantry,
 /obj/item/ammo_magazine/mil_rifle/sec/large,
 /obj/item/ammo_magazine/mil_rifle/sec/large,
 /obj/structure/window/reinforced{
@@ -17007,6 +17026,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/rig/recon/infantry,
 /turf/simulated/floor/tiled/dark,
 /area/infantry/inftech)
 "SG" = (
@@ -17455,7 +17475,6 @@
 /area/shuttle/petrov/maint)
 "Ua" = (
 /obj/structure/closet/secure_closet/squad_lead,
-/obj/item/weapon/rig/military/infantry,
 /obj/item/weapon/storage/firstaid/adv,
 /obj/item/clothing/accessory/storage/black_vest,
 /obj/item/device/radio,
@@ -17469,6 +17488,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
+/obj/item/weapon/rig/recon/infantry,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
 "Ub" = (
@@ -17720,7 +17740,7 @@
 	},
 /obj/structure/cable/green,
 /obj/machinery/door/firedoor,
-/turf/space,
+/turf/simulated/floor/plating,
 /area/infantry)
 "Ve" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17757,7 +17777,6 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "Vn" = (
 /obj/structure/closet/secure_closet/infantry,
-/obj/item/weapon/rig/military/infantry,
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
@@ -17769,6 +17788,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/rig/recon/infantry,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
 "Vo" = (
@@ -18179,7 +18199,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/space,
+/turf/simulated/floor/plating,
 /area/infantry)
 "WL" = (
 /obj/machinery/vending/security/infantry,
@@ -19180,7 +19200,6 @@
 /area/shuttle/petrov/analysis)
 "ZW" = (
 /obj/structure/closet/secure_closet/infantry,
-/obj/item/weapon/rig/military/infantry,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -19193,6 +19212,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/rig/recon/infantry,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
 "ZY" = (
@@ -31606,7 +31626,7 @@ IJ
 IJ
 IJ
 Yt
-ET
+wC
 Rh
 ET
 ME


### PR DESCRIPTION
As Infantry is ((hopefully)) changed to Recon, changed their rigs up
🆑
rscadd: "Added new Recon hardsuits to infantry prep."
rscadd: "Added two doors, respectively SL and CT"
tweak: "Fixed the two tiles in space, also in infantry prep"
/ 🆑

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->