### PR TITLE
Tidies up job positions.

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -35,7 +35,6 @@
 						/datum/job/qm, /datum/job/cargo_tech, /datum/job/mining,
 						/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
 						/datum/job/senior_scientist, /datum/job/scientist, /datum/job/roboticist, /datum/job/scientist_assistant,
-						/datum/job/cyborg,
 						/datum/job/crew, /datum/job/assistant,
 						/datum/job/merchant,
 						/datum/job/squad_lead, /datum/job/combat_tech, /datum/job/grunt,

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -26,24 +26,21 @@
 #undef HUMAN_ONLY_JOBS
 
 	allowed_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos,
-						/datum/job/liaison, /datum/job/bodyguard, /datum/job/representative, /datum/job/sea,
+						/datum/job/liaison, /datum/job/bodyguard, /datum/job/representative, /datum/job/psiadvisor, /datum/job/sea, /datum/job/sea/marine,
 						/datum/job/bridgeofficer, /datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer,
-						/datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/engineer_trainee,
-						/datum/job/officer, /datum/job/warden, /datum/job/detective,
-						/datum/job/senior_doctor, /datum/job/doctor, /datum/job/junior_doctor, /datum/job/chemist, /datum/job/medical_trainee,
+						/datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_trainee,
+						/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/seccadet,
+						/datum/job/senior_doctor, /datum/job/biomech, /datum/job/doctor, /datum/job/junior_doctor, /datum/job/chemist, /datum/job/medical_trainee,
 						/datum/job/psychiatrist, /datum/job/chaplain,
 						/datum/job/qm, /datum/job/cargo_tech, /datum/job/mining,
 						/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
-						/datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant,
+						/datum/job/senior_scientist, /datum/job/scientist, /datum/job/roboticist, /datum/job/scientist_assistant,
 						/datum/job/cyborg,
 						/datum/job/crew, /datum/job/assistant,
 						/datum/job/merchant,
 						/datum/job/squad_lead, /datum/job/combat_tech, /datum/job/grunt,
 						/datum/job/ai,
-						/datum/job/biomech,
-						/datum/job/psiadvisor,
-						/datum/job/seccadet,
-						/datum/job/sea/marine,
+						/datum/job/cyborg,
 	)
 
 	access_modify_region = list(


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

This puts each job in its proper location on the "occupations" screen, from:

![2showcase](https://user-images.githubusercontent.com/54181477/102087286-134e1480-3df8-11eb-934f-572da596792e.PNG)

To: 

![1showcase](https://user-images.githubusercontent.com/54181477/102088300-8015de80-3df9-11eb-9a1f-dc3e5953322c.PNG)
