### PR TITLE
Removes SEA and SMC attache earm access

### DIFF
--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -281,7 +281,7 @@ var/const/INF               =(1<<11)
 	access = list(access_medical, access_engine, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_janitor,
 			            access_kitchen, access_cargo, access_RC_announce, access_keycard_auth, access_guppy_helm,
-			            access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_emergency_armory, access_gunnery, access_infantry)
+			            access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_gunnery, access_infantry)
 
 	software_on_spawn = list(/datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/reports)


### PR DESCRIPTION
:cl:
tweak: SEA and SMC Attache no longer have access to the emergency armory.
/:cl:

The motivation of this is to prevent attaches from valid hunting. Their job is to act as an advisor to the command staff on all matters Marines, and they do not need access to the emergency armory to do this job. 