### PR TITLE
Ascent Language Tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/preset.dm
+++ b/code/modules/mob/living/silicon/robot/preset.dm
@@ -50,8 +50,6 @@
 
 /mob/living/silicon/robot/flying/ascent/Initialize()
 	. = ..()
-	remove_language(LANGUAGE_HUMAN_EURO)
-	remove_language(LANGUAGE_EAL)
 	remove_language(LANGUAGE_ROBOT_GLOBAL)
 	default_language = all_languages[LANGUAGE_MANTID_NONVOCAL]
 

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -438,7 +438,8 @@
 		BP_HEART =             /obj/item/organ/internal/heart/open,
 		BP_LIVER =             /obj/item/organ/internal/liver/insectoid/nabber,
 		BP_STOMACH =           /obj/item/organ/internal/stomach/insectoid,
-		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller
+		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller,
+		BP_VOICE =    /obj/item/organ/internal/voicebox/nabber
 	)
 
 	force_cultural_info = list(
@@ -490,7 +491,8 @@
 		BP_LIVER =             /obj/item/organ/internal/liver/insectoid/nabber,
 		BP_HEART =             /obj/item/organ/internal/heart/open,
 		BP_STOMACH =           /obj/item/organ/internal/stomach,
-		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller
+		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller,
+		BP_VOICE =    /obj/item/organ/internal/voicebox/nabber
 		)
 
 	has_limbs = list(


### PR DESCRIPTION
Gives Monarchs the GAS voice box, allowing them to actually speak in human languages.
Gives Drones ZAC and EAL, while I'm at it.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->