### PR TITLE
Various fixes n' tweaks

### DIFF
--- a/code/datums/vote/gamemode.dm
+++ b/code/datums/vote/gamemode.dm
@@ -30,9 +30,10 @@
 	display_choices["secret"] = "Secret"
 
 /datum/vote/gamemode/handle_default_votes()
-	var/non_voters = ..()
+	..()
+	//var/non_voters = ..()
 /*	if(SSticker.master_mode in choices)  # VESTA.BAY # REMOVE NON-VOTERS BEING COUNTED AS VOTES TO EXTENDED
-		choices[SSticker.master_mode] += non_voters*/ 
+		choices[SSticker.master_mode] += non_voters*/
 
 /datum/vote/gamemode/report_result()
 	if(!SSticker.round_progressing) //Unpause any holds. If the vote failed, SSticker is responsible for fielding the result.

--- a/code/datums/vote/gamemode.dm
+++ b/code/datums/vote/gamemode.dm
@@ -31,8 +31,8 @@
 
 /datum/vote/gamemode/handle_default_votes()
 	var/non_voters = ..()
-	if(SSticker.master_mode in choices)
-		choices[SSticker.master_mode] += non_voters
+/*	if(SSticker.master_mode in choices)  # VESTA.BAY # REMOVE NON-VOTERS BEING COUNTED AS VOTES TO EXTENDED
+		choices[SSticker.master_mode] += non_voters*/ 
 
 /datum/vote/gamemode/report_result()
 	if(!SSticker.round_progressing) //Unpause any holds. If the vote failed, SSticker is responsible for fielding the result.

--- a/html/changelogs/Radioaction-Cyber-PR-#110
+++ b/html/changelogs/Radioaction-Cyber-PR-#110
@@ -1,0 +1,49 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Radioaction-Cyber
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Amassed jobs for easier global access for editting."
+  - rscadd: "Added maintenance and robotics access to Science staff."
+  - rscadd: "Hangar access added to Medical staff."
+  - rscadd: "Trained Science minimum re-added to Bridge Officers."
+  - rscadd: "Psi Advisors fixed to be able to take holsters during loadout."
+  - rscadd: "Fixed SAARE/PCRC APA incapable of getting SAARE/PCRC Beret."
+  - rscadd: "Added maintenance and research access to Liason/APA."
+  - rscadd: "Fixed Fleet being unable to get skill badges."
+  - rscadd: "Made all webbings/drop pouches accessible in loadout to all roles again."
+  - rscadd: "Gave Bridge Officers access to their Bridge Arm Lockers again."
+  - rscadd: "Gave SMC their helmet covers back."
+  - rscadd: "Added SMC to Solgov Branches list."
+  

--- a/html/changelogs/Radioaction-Cyber-PR-#110.yml
+++ b/html/changelogs/Radioaction-Cyber-PR-#110.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Radioaction-Cyber
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Trained Science minimum added back to Bridge Officers."
+  - rscadd: "Added Hangar access to Medical staff."
+  - rscadd: "Added maint and robotics access to Science staff."
+  - tweak: "Allowed Psi Advisors to take holsters during loadout."

--- a/html/changelogs/r4iser-PR-109.yml
+++ b/html/changelogs/r4iser-PR-109.yml
@@ -1,0 +1,6 @@
+author: Peekaboom
+
+delete-after: True
+
+changes: 
+  - tweak: "Removed non-voters being counted as Extended votes."

--- a/modular_boh/code/game/loadout/loadout_accessories.dm
+++ b/modular_boh/code/game/loadout/loadout_accessories.dm
@@ -114,24 +114,22 @@
 	allowed_roles = STERILE_ROLES
 
 /datum/gear/storage/brown_vest
-	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
-						/datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/engineer_trainee, /datum/job/explorer, /datum/job/nt_pilot, /datum/job/pathfinder, /datum/job/submap/CTI_pilot, /datum/job/submap/CTI_engineer, /datum/job/submap/scavver_pilot, /datum/job/submap/scavver_doctor, /datum/job/submap/scavver_engineer)
+	allowed_branches = TACTICOOL_BRANCHES, CIVILIAN_BRANCHES
 
 /datum/gear/storage/black_vest
-	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/merchant)
+	allowed_branches = TACTICOOL_BRANCHES, CIVILIAN_BRANCHES
 
 /datum/gear/storage/white_vest
-	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/junior_doctor, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/chemist, /datum/job/merchant, /datum/job/medical_trainee)
+	allowed_branches = TACTICOOL_BRANCHES, CIVILIAN_BRANCHES
 
 /datum/gear/storage/brown_drop_pouches
-	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
-						/datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/engineer_trainee, /datum/job/submap/CTI_pilot, /datum/job/submap/CTI_engineer, /datum/job/submap/scavver_pilot, /datum/job/submap/scavver_doctor, /datum/job/submap/scavver_engineer)
+	allowed_branches = TACTICOOL_BRANCHES, CIVILIAN_BRANCHES
 
 /datum/gear/storage/black_drop_pouches
-	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/merchant)
+	allowed_branches = TACTICOOL_BRANCHES, CIVILIAN_BRANCHES
 
 /datum/gear/storage/white_drop_pouches
-	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/junior_doctor, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/chemist, /datum/job/merchant, /datum/job/medical_trainee)
+	allowed_branches = TACTICOOL_BRANCHES, CIVILIAN_BRANCHES
 
 /datum/gear/tactical/holster
 	allowed_roles = ARMED_ROLES
@@ -158,7 +156,7 @@
 	allowed_roles = list(/datum/job/assistant)
 
 /datum/gear/tactical/helm_covers
-	allowed_roles = ARMORED_ROLES
+	allowed_branches = TACTICOOL_BRANCHES
 
 /datum/gear/clothing/hawaii
 	allowed_roles = SEMIFORMAL_ROLES

--- a/modular_boh/code/items/clothing/ec_skillbadges.dm
+++ b/modular_boh/code/items/clothing/ec_skillbadges.dm
@@ -13,47 +13,63 @@
 	I.color = badgecolor
 	return I
 
+
+
 /obj/item/clothing/accessory/solgov/skillbadge/botany
 	name = "\improper Field Xenobotany Specialist badge"
 	desc = "An NT skill badge signifying that the bearer has passed the advanced training on handling exotic xenoflora. Informally known as 'Vine Wrangler'."
 	icon_state = "ec_badge_botany"
 	badgecolor = "#387c4f"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillbadge/netgun
 	name = "\improper Xenofauna Acquisition Specialist badge"
 	desc = "An NT skill badge signifying that the bearer has passed the advanced training on capturing alien wildlife with the netgun. Informally known as 'Xeno-Cowboy'."
 	icon_state = "ec_badge_netgun"
 	badgecolor = "#6a60a1"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillbadge/eva
 	name = "\improper Void Mobility Specialist badge"
 	desc = "An NT skill badge signifying that the bearer has passed the advanced training on moving around in zero-g using a jetpack. Informally known as 'Zoomer'."
 	icon_state = "ec_badge_eva"
 	badgecolor = "#4d9799"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillbadge/medical
 	name = "\improper Advanced First Aid Specialist badge"
 	desc = "An NT skill badge signifying that the bearer has passed the advanced training on CPR and basic medical tech. Informally known as 'Para-paramedic'."
 	icon_state = "ec_badge_med"
 	badgecolor = "#47799e"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillbadge/mech
 	name = "\improper Exosuit Specialist badge"
 	desc = "An NT skill badge signifying that the bearer has passed the advanced training on piloting exosuits. Informally known as 'Exonaut'."
 	icon_state = "ec_badge_exo"
 	badgecolor = "#72763d"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillbadge/electric
 	name = "\improper Electrical Specialist badge"
 	desc = "An NT skill badge signifying that the bearer has passed the advanced training on working with high-voltage electrical systems. Informally known as 'Jury-rigger'."
 	icon_state = "ec_badge_electro"
 	badgecolor = "#8e633f"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillbadge/science
 	name = "\improper Research Specialist badge"
 	desc = "An NT skill badge signifying that the bearer has passed the advanced training on assisting in the labs and working the sensor suites. Informally known as 'Peeper'."
 	icon_state = "ec_badge_sci"
 	badgecolor = "#7876ad"
+   allowed_branches = NT_BRANCHES
+
 
 // Voidsuit accessory
 
@@ -64,28 +80,40 @@
 	on_rolled = list("down" = "none")
 	high_visibility = 1
 	icon_state = "ec_stripe"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillstripe/botany
 	name = "xenobotanist stripe"
 	desc = "A thin stripe of spaceworthy material with vacuum-rated adhesive, for attaching to the voidsuit. Indicates Field Xenobotany Specialist training."
 	color = "#387c4f"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillstripe/netgun
 	name = "netgunner stripe"
 	desc = "A thin stripe of spaceworthy material with vacuum-rated adhesive, for attaching to the voidsuit. Indicates Xenofauna Acquisition Specialist training."
 	color = "#6a60a1"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillstripe/eva
 	name = "void stripe"
 	desc = "A thin stripe of spaceworthy material with vacuum-rated adhesive, for attaching to the voidsuit. Indicates Void Mobility Specialist training."
 	color = "#3d7172"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillstripe/medical
 	name = "medic stripe"
 	desc = "A thin stripe of spaceworthy material with vacuum-rated adhesive, for attaching to the voidsuit. Indicates Advanced First Aid Specialist training."
 	color = "#2d6295"
+   allowed_branches = NT_BRANCHES
+
 
 /obj/item/clothing/accessory/solgov/skillstripe/electric
 	name = "electrician stripe"
 	desc = "A thin stripe of spaceworthy material with vacuum-rated adhesive, for attaching to the voidsuit. Indicates Electrical Specialist training."
 	color = "#8e633f"
+   allowed_branches = NT_BRANCHES
+

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -18,7 +18,11 @@ var/const/INF               =(1<<11)
 /decl/hierarchy/outfit/job/security/infantry/grunt
 	name = OUTFIT_JOB_NAME("Rifleman")
 
-//Infantry Jobs
+
+	//############# INFANTRY
+	//############# SQUAD LEADER
+
+
 /datum/job/squad_lead
 	title = "Squad Lead"
 	department = "Infantry"
@@ -57,6 +61,10 @@ var/const/INF               =(1<<11)
 
 /datum/job/squad_lead/get_description_blurb()
 	return "<span class='warning'>You are NOT Security. Ignoring this will get you job banned, or worse.</span> - You are a Squad Leader. Your duty is to organize and lead the small infantry squad to support the Pathfinder. You command Marines in your Squad. You make sure that expedition has the firepower it needs. Once on the away mission, your duty is to ensure that the worst doesn't become reality."
+
+
+	//############# COMBAT TECHNICIAN
+
 
 /datum/job/combat_tech
 	title = "Combat Technician"
@@ -107,6 +115,10 @@ var/const/INF               =(1<<11)
 /datum/job/combat_tech/get_description_blurb()
 	return "<span class='warning'>You are NOT Security. Ignoring this will get you job banned, or worse.</span> - You are the singular Combat Technician in the squad. Your duty is to provide both firepower and demolitions as required. You may assume Command if no Squad Leader is present."
 
+
+	//############# RIFLEMAN
+
+
 /datum/job/grunt
 	title = "Rifleman"
 	department = "Infantry"
@@ -153,97 +165,348 @@ var/const/INF               =(1<<11)
 /datum/job/grunt/get_description_blurb()
 	return "<span class='warning'>You are NOT Security. Ignoring this will get you job banned, or worse.</span> - You are a Marine! Your duty is to listen to the Squad Leader. If they're not present, the Combat Technician may pull rank. Do your best not to die, while also taking orders. Oorah!"
 
-//############# PSYKER
 
-/datum/job/psiadvisor
-	title = "Psionic Advisor"
-	department = "Support"
-	department_flag = SPT
-	department = "Civilian"
-	department_flag = CIV
-	selection_color = "#2f2f7f"
-	total_positions = 1
-	spawn_positions = 1
-	economic_power = 30
-	minimum_character_age = list(SPECIES_HUMAN = 25,SPECIES_UNATHI = 25,SPECIES_SERGAL = 25, SPECIES_SKRELL = 25, SPECIES_PROMETHEAN = 25, SPECIES_YEOSA = 25, SPECIES_VASS = 25, SPECIES_TAJ = 25, SPECIES_CUSTOM = 25, SPECIES_AKULA = 25)
-	//minimal_player_age = 7	//DEACTIVATED FOR DEBUG PURPOSES
-	supervisors = "NTPC or the Foundation, neither secondary to the Commanding Officer"
-	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/psiadvisor
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/foundationadvisor)
-	min_skill = list(
-		SKILL_BUREAUCRACY = SKILL_EXPERT,
-		SKILL_FINANCE = SKILL_ADEPT,
-		SKILL_MEDICAL = SKILL_BASIC
-	)
-	max_skill = list(
-		SKILL_COMBAT     = SKILL_EXPERT,
-		SKILL_WEAPONS     = SKILL_EXPERT
-	)
-	skill_points = 30
-	access = list(access_psiadvisor, access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks,
-				access_eva, access_bridge, access_cargo, access_RC_announce, access_solgov_crew, access_hangar)
-	minimal_access = list()
-	software_on_spawn = list(
-		/datum/computer_file/program/comm,
-		/datum/computer_file/program/records
-	)
+	//############# COMMAND
+	//############# COMMANDING OFFICER
 
-	alt_titles = list(
-		"Nanotrasen Psionic Operative" = /decl/hierarchy/outfit/job/torch/crew/command/psiadvisor/nt,
-		"Foundation Agent")
 
-/datum/job/psiadvisor/equip(var/mob/living/carbon/human/H)
-	psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT, "[PSI_COERCION]" = PSI_RANK_OPERANT, "[PSI_PSYCHOKINESIS]" = PSI_RANK_OPERANT, "[PSI_ENERGISTICS]" = PSI_RANK_OPERANT)
-	return ..()
-
-/datum/job/psiadvisor/get_description_blurb()
-	return "You are the Psionic Advisor, an agent of either the Foundation or Nanotrasen Psionic Corps. Alongside the Counselor, you're the only other individual with known and authorized Psionic abilities aboard the NTSS Dagon. Your main responsibility is advising the Commanding Officer on psionic matters. \
-	Secondly, you're to assist the crew or Research on psionic matters, or guide any newly emergent crew that awaken with psionic abilities."
-
-//##### SEC CADET
-
-/datum/job/seccadet
-	title = "Security Cadet"
-	department = "Security"
-	department_flag = SEC
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "the entirety of Security"
-	economic_power = 1
-	minimal_player_age = 0
-	minimum_character_age = list(SPECIES_HUMAN = 18)
-	selection_color = "#601c1c"
-	alt_titles = list(
-		"Forensics Trainee"
-		)
-	min_skill = list(   SKILL_EVA         = SKILL_ADEPT,
-	                    SKILL_COMBAT      = SKILL_BASIC)
-	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
-	                    SKILL_WEAPONS     = SKILL_EXPERT,
-	                    SKILL_FORENSICS   = SKILL_EXPERT)
-	skill_points = 16
-	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/maa
+/datum/job/captain
+	title = "Commanding Officer"
+	supervisors = "NanoTrasen Central Command"
+	minimal_player_age = 14
+	economic_power = 16
+	minimum_character_age = list(SPECIES_HUMAN = 40)
+	ideal_character_age = 50
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/CO
 	allowed_branches = list(
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/security/maa/fleet,
-		/datum/mil_branch/marine_corps
+		/datum/mil_branch/expeditionary_corps
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/marine_corps/e2,
-		/datum/mil_rank/marine_corps/e3
+		/datum/mil_rank/ec/o6
 	)
-	access = list(access_security, access_brig, access_maint_tunnels,
-						access_external_airlocks, access_emergency_storage,
-			            access_eva, access_sec_doors, access_solgov_crew)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_SCIENCE     = SKILL_ADEPT,
+	                    SKILL_PILOT       = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
+	skill_points = 30
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/card_mod,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/reports)
+
+/datum/job/captain/get_description_blurb()
+	return "You are the Commanding Officer. You are the top dog. You are an experienced professional officer or company executive in control of an entire ship, and ultimately responsible for all that happens onboard. Your job is to make sure [GLOB.using_map.full_name] fulfils its directives. Delegate to your Executive Officer, your department heads, and your Senior Enlisted Advisor to effectively manage the ship, and listen to and trust their expertise."
+
+/datum/job/captain/post_equip_rank(var/mob/person, var/alt_title)
+	var/sound/announce_sound = (GAME_STATE <= RUNLEVEL_SETUP)? null : sound('sound/misc/boatswain.ogg', volume=20)
+	captain_announcement.Announce("All personnel, [alt_title || title] [person.real_name] on deck!", new_sound = announce_sound)
+	..()
+
+
+	//############# XO
+
+
+	/datum/job/hop
+	title = "Executive Officer"
+	supervisors = "the Commanding Officer"
+	department = "Command"
+	department_flag = COM
+	minimal_player_age = 14
+	economic_power = 14
+	minimum_character_age = list(SPECIES_HUMAN = 35)
+	ideal_character_age = 45
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/XO
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/command/XO/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o5,
+		/datum/mil_rank/fleet/o4,
+		/datum/mil_rank/fleet/o5
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_PILOT       = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
+	skill_points = 30
+
+	access = list(access_security, access_brig, access_armory, access_forensics_lockers, access_heads, access_medical, access_morgue, access_tox, access_tox_storage,
+					access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
+					access_ai_upload, access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_chapel_office, access_tech_storage,
+					access_atmospherics, access_bar, access_janitor, access_crematorium, access_kitchen, access_robotics, access_cargo, access_construction,
+					access_chemistry, access_cargo_bot, access_hydroponics, access_manufacturing, access_library, access_lawyer, access_virology, access_cmo,
+					access_qm, access_network, access_surgery, access_research, access_mining, access_mining_office, access_mailsorting, access_heads_vault,
+					access_mining_station, access_xenobiology, access_ce, access_hop, access_hos, access_RC_announce, access_keycard_auth, access_tcomsat,
+					access_gateway, access_sec_doors, access_psychiatrist, access_xenoarch, access_medical_equip, access_heads, access_hangar, access_guppy_helm,
+					access_expedition_shuttle_helm, access_aquila, access_aquila_helm, access_solgov_crew, access_nanotrasen,
+					access_emergency_armory, access_sec_guard, access_gun, access_expedition_shuttle, access_guppy, access_seneng, access_senmed, access_senadv,
+					access_explorer, access_pathfinder, access_pilot, access_commissary, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
+					access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd, access_torch_fax, access_torch_helm)
+	minimal_access = list(access_security, access_brig, access_armory, access_forensics_lockers, access_heads, access_medical, access_morgue, access_tox, access_tox_storage,
+						access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
+						access_ai_upload, access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_chapel_office, access_tech_storage,
+						access_atmospherics, access_bar, access_janitor, access_crematorium, access_kitchen, access_robotics, access_cargo, access_construction,
+						access_chemistry, access_cargo_bot, access_hydroponics, access_manufacturing, access_library, access_lawyer, access_virology, access_cmo,
+						access_qm, access_network, access_surgery, access_research, access_mining, access_mining_office, access_mailsorting, access_heads_vault,
+						access_mining_station, access_xenobiology, access_ce, access_hop, access_hos, access_RC_announce, access_keycard_auth, access_tcomsat,
+						access_gateway, access_sec_doors, access_psychiatrist, access_xenoarch, access_medical_equip, access_heads, access_hangar, access_guppy_helm,
+						access_expedition_shuttle_helm, access_aquila, access_aquila_helm, access_solgov_crew, access_nanotrasen,
+						access_emergency_armory, access_sec_guard, access_gun, access_expedition_shuttle, access_guppy, access_seneng, access_senmed, access_senadv,
+						access_explorer, access_pathfinder, access_pilot, access_commissary, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
+						access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd, access_torch_fax, access_torch_helm)
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/card_mod,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/reports)
+
+/datum/job/hop/get_description_blurb()
+	return "You are the Executive Officer. You are an experienced senior officer or company manager, second in command of the ship, and are responsible for the smooth operation of the ship under your Commanding Officer. In their absence, you are expected to take their place. Your primary duty is directly managing department heads and all those outside a department heading. You are also responsible for the contractors and passengers aboard the ship. Consider the Senior Enlisted Advisor and Bridge Officers tools at your disposal."
+
+
+	//############# CSO
+
+
+/datum/job/rd
+	title = "Chief Science Officer"
+	supervisors = "the Commanding Officer"
+	economic_power = 12
+	minimal_player_age = 14
+	minimum_character_age = list(SPECIES_HUMAN = 35)
+	ideal_character_age = 60
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/cso
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o3
+	)
+
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_FINANCE     = SKILL_ADEPT,
+	                    SKILL_BOTANY      = SKILL_BASIC,
+	                    SKILL_ANATOMY     = SKILL_BASIC,
+	                    SKILL_DEVICES     = SKILL_BASIC,
+	                    SKILL_SCIENCE     = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
+	skill_points = 30
+
+	access = list(
+		access_tox, access_tox_storage, access_emergency_storage, access_teleporter, access_bridge, access_rd,
+		access_research, access_mining, access_mining_office, access_mining_station, access_xenobiology, access_aquila,
+		access_RC_announce, access_keycard_auth, access_xenoarch, access_nanotrasen, access_sec_guard, access_heads,
+		access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
+		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_rd,
+		access_petrov_security, access_petrov_maint, access_pathfinder, access_explorer, access_robotics, access_eva, access_solgov_crew,
+		access_expedition_shuttle, access_expedition_shuttle_helm, access_maint_tunnels, access_torch_fax
+	)
 	minimal_access = list()
-	software_on_spawn = list(/datum/computer_file/program/digitalwarrant)
 
-/datum/job/seccadet/get_description_blurb()
-	return "You're either a new hire, or a new trainee aboard the [GLOB.using_map.full_name]. Everyone is your senior, and as such, you'd best listen to them."
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/aidiag,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/reports)
 
-//## SEA
+/datum/job/rd/get_description_blurb()
+	return "You are the Chief Science Officer. You are responsible for the research department. You handle the science aspects of the project and liase with the corporate interests of NanoTrasen. Make sure science gets done, do some yourself, and get your scientists on away missions to find things to benefit the project. Advise the CO on science matters."
+
+
+	//############# CMO
+
+
+/datum/job/cmo
+	title = "Chief Medical Officer"
+	supervisors = "the Commanding Officer and the Executive Officer"
+	economic_power = 14
+	minimal_player_age = 14
+	minimum_character_age = list(SPECIES_HUMAN = 35)
+	ideal_character_age = 48
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/cmo
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/command/cmo/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4,
+		/datum/mil_rank/ec/o3
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_EXPERT,
+	                    SKILL_CHEMISTRY   = SKILL_BASIC,
+						SKILL_DEVICES     = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	skill_points = 26
+
+	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_teleporter, access_eva, access_bridge, access_heads,
+			            access_chapel_office, access_crematorium, access_chemistry, access_virology, access_aquila,
+			            access_cmo, access_surgery, access_RC_announce, access_keycard_auth, access_psychiatrist,
+			            access_medical_equip, access_solgov_crew, access_senmed, access_hangar, access_torch_fax)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/reports)
+
+/datum/job/cmo/get_description_blurb()
+	return "You are the Chief Medical Officer. You manage the medical department. You ensure all members of medical are skilled, tasked and handling their duties. Ensure your doctors are staffing your infirmary and your doctors/paramedics are ready for response. Act as a second surgeon or backup pharmacist in the absence of either. You are expected to know medical very well, along with general regulations."
+
+
+//############# CE
+
+
+/datum/job/chief_engineer
+	title = "Chief Engineer"
+	supervisors = "the Commanding Officer and the Executive Officer"
+	economic_power = 12
+	minimum_character_age = list(SPECIES_HUMAN = 27)
+	ideal_character_age = 40
+	minimal_player_age = 14
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o3,
+		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/fleet/o3
+	)
+	min_skill = list(   SKILL_BUREAUCRACY  = SKILL_BASIC,
+	                    SKILL_COMPUTER     = SKILL_ADEPT,
+	                    SKILL_EVA          = SKILL_ADEPT,
+	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_ELECTRICAL   = SKILL_ADEPT,
+	                    SKILL_ATMOS        = SKILL_ADEPT,
+	                    SKILL_ENGINES      = SKILL_EXPERT)
+
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
+	skill_points = 30
+
+	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
+			            access_tech_storage, access_atmospherics, access_janitor, access_construction,
+			            access_network, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,
+			            access_solgov_crew, access_aquila, access_seneng, access_hangar, access_torch_fax, access_torch_helm)
+	minimal_access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
+			            access_tech_storage, access_atmospherics, access_janitor, access_construction,
+			            access_network, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,
+			            access_solgov_crew, access_seneng, access_hangar, access_torch_fax, access_torch_helm)
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/ntnetmonitor,
+							 /datum/computer_file/program/power_monitor,
+							 /datum/computer_file/program/supermatter_monitor,
+							 /datum/computer_file/program/alarm_monitor,
+							 /datum/computer_file/program/atmos_control,
+							 /datum/computer_file/program/rcon_console,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/shields_monitor,
+							 /datum/computer_file/program/reports)
+
+/datum/job/chief_engineer/get_description_blurb()
+	return "You are the Chief Engineer. You manage the Engineering Department. You are responsible for the Senior engineer, who is your right hand and (should be) an experienced, skilled engineer. Delegate to and listen to them. Manage your engineers, ensure vessel power stays on, breaches are patched and problems are fixed. Advise the CO on engineering matters. You are also responsible for the maintenance and control of any vessel synthetics. You are an experienced engineer with a wealth of theoretical knowledge. You should also know vessel regulations to a reasonable degree."
+
+
+//############# COS
+
+
+/datum/job/hos
+	title = "Chief of Security"
+	supervisors = "the Commanding Officer and the Executive Officer"
+	economic_power = 10
+	minimal_player_age = 14
+	minimum_character_age = list(SPECIES_HUMAN = 25)
+	ideal_character_age = 35
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/cos
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/command/cos/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o3,
+		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/fleet/o3
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
+
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_MAX)
+	skill_points = 28
+
+	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
+			            access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_teleporter, access_eva, access_bridge, access_heads, access_aquila,
+			            access_hos, access_RC_announce, access_keycard_auth, access_sec_doors,
+			            access_solgov_crew, access_gun, access_emergency_armory, access_hangar, access_torch_fax)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/digitalwarrant,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/reports)
+
+/datum/job/hos/get_description_blurb()
+	return "You are the Chief of Security. You manage ship security. The Masters at Arms and the Military Police, as well as the Brig Chief and the Forensic Technician. You keep the vessel safe. You handle both internal and external security matters. You are the law. You are subordinate to the CO and the XO. You are expected to know the NTEF Regulations and Standard Operating Procedures to a very high degree along with Sol Law."
+
+
+	//############# SOLGOV REP
+
+
+	/datum/job/representative
+	title = "SolGov Representative"
+	department = "Support"
+	department_flag = SPT
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Solarian Government"
+	selection_color = "#2f2f7f"
+	economic_power = 16
+	minimal_player_age = 0
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/representative
+	allowed_branches = list(/datum/mil_branch/solgov)
+	allowed_ranks = list(/datum/mil_rank/sol/gov)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_EXPERT,
+	                    SKILL_FINANCE     = SKILL_BASIC)
+	skill_points = 20
+	minimum_character_age = list(SPECIES_HUMAN = 27)
+
+	access = list(access_representative, access_security, access_medical,
+			            access_bridge, access_cargo, access_solgov_crew, access_hangar, access_torch_fax)
+
+	software_on_spawn = list(/datum/computer_file/program/reports)
+
+/datum/job/representative/get_description_blurb()
+	return "You are the Sol Gov Representative. You are a civilian assigned as both a diplomatic liaison for first contact and foreign affair situations on board. You are also responsible for monitoring for any serious missteps of justice, sol law or other ethical or legal issues aboard and informing and advising SolGov of them. You are a mid-level bureaucrat. You liaise between the crew and SolGov interests on board. Send faxes back to Sol on mission progress and important events."
+
+
+	//############# SEA & ATTACHEE
+
 
 /datum/job/sea	//Overrides it to make it like ours @r4iser
 	title = "Senior Enlisted Advisor"
@@ -306,7 +569,924 @@ var/const/INF               =(1<<11)
 		/datum/mil_rank/marine_corps/o3
 	)
 
-//## RESEARCH ROBOTICIST
+
+	//############# BRIDGE OFFICER
+
+
+/datum/job/bridgeofficer
+	title = "Bridge Officer"
+	department = "Support"
+	department_flag = SPT
+	total_positions = 3
+	spawn_positions = 3
+	supervisors = "the Commanding Officer and heads of staff"
+	selection_color = "#2f2f7f"
+	minimal_player_age = 0
+	economic_power = 8
+	minimum_character_age = list(SPECIES_HUMAN = 22)
+	ideal_character_age = 24
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o1,
+		/datum/mil_rank/fleet/o1
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_PILOT       = SKILL_ADEPT
+	                    SKILL_SCIENCE     = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+	skill_points = 20
+
+
+	access = list(access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
+			            access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
+			            access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
+			            access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,
+			            access_torch_fax, access_torch_helm, access_gun)
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/power_monitor,
+							 /datum/computer_file/program/supermatter_monitor,
+							 /datum/computer_file/program/alarm_monitor,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/shields_monitor,
+							 /datum/computer_file/program/reports,
+							 /datum/computer_file/program/deck_management)
+
+/datum/job/bridgeofficer/get_description_blurb()
+	return "You are a Bridge Officer. You are a very junior officer. You do not give orders of your own. You are subordinate to all of command. You handle matters on the bridge and report directly to the CO and XO. You take the Dagon's helm and pilot the Byakhee if needed. You monitor bridge computer programs and communications and report relevant information to command."
+
+
+	//############# PSIONIC ADVISOR
+
+
+/datum/job/psiadvisor
+	title = "Psionic Advisor"
+	department = "Support"
+	department_flag = SPT
+	selection_color = "#2f2f7f"
+	total_positions = 1
+	spawn_positions = 1
+	economic_power = 30
+	minimum_character_age = list(SPECIES_HUMAN = 25,SPECIES_UNATHI = 25,SPECIES_SERGAL = 25, SPECIES_SKRELL = 25, SPECIES_PROMETHEAN = 25, SPECIES_YEOSA = 25, SPECIES_VASS = 25, SPECIES_TAJ = 25, SPECIES_CUSTOM = 25, SPECIES_AKULA = 25)
+	//minimal_player_age = 7	//DEACTIVATED FOR DEBUG PURPOSES
+	supervisors = "NTPC or the Foundation, neither secondary to the Commanding Officer"
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/psiadvisor
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(/datum/mil_rank/civ/foundationadvisor)
+	min_skill = list(
+		SKILL_BUREAUCRACY = SKILL_EXPERT,
+		SKILL_FINANCE = SKILL_ADEPT,
+		SKILL_MEDICAL = SKILL_BASIC
+	)
+	max_skill = list(
+		SKILL_COMBAT     = SKILL_EXPERT,
+		SKILL_WEAPONS     = SKILL_EXPERT
+	)
+	skill_points = 30
+	access = list(access_psiadvisor, access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks,
+				access_eva, access_bridge, access_cargo, access_RC_announce, access_solgov_crew, access_hangar)
+	minimal_access = list()
+	software_on_spawn = list(
+		/datum/computer_file/program/comm,
+		/datum/computer_file/program/records
+	)
+
+	alt_titles = list(
+		"Nanotrasen Psionic Operative" = /decl/hierarchy/outfit/job/torch/crew/command/psiadvisor/nt,
+		"Foundation Agent")
+
+/datum/job/psiadvisor/equip(var/mob/living/carbon/human/H)
+	psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT, "[PSI_COERCION]" = PSI_RANK_OPERANT, "[PSI_PSYCHOKINESIS]" = PSI_RANK_OPERANT, "[PSI_ENERGISTICS]" = PSI_RANK_OPERANT)
+	return ..()
+
+/datum/job/psiadvisor/get_description_blurb()
+	return "You are the Psionic Advisor, an agent of either the Foundation or Nanotrasen Psionic Corps. Alongside the Counselor, you're the only other individual with known and authorized Psionic abilities aboard the NTSS Dagon. Your main responsibility is advising the Commanding Officer on psionic matters. \
+	Secondly, you're to assist the crew or Research on psionic matters, or guide any newly emergent crew that awaken with psionic abilities."
+
+
+	//############# CORPORATE
+	//############# CORPORATE LIAISON
+
+
+	/datum/job/liaison
+	title = "Workplace Liaison"
+	department = "Support"
+	department_flag = SPT
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "your Corporate Executives, Shareholders, and Investors."
+	selection_color = "#2f2f7f"
+	economic_power = 18
+	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 25)
+	alt_titles = list(
+		"Corporate Liaison",
+		"Union Representative",
+		"Corporate Representative",
+		"Corporate Executive"
+		)
+	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/workplace_liaison
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	min_skill = list(   SKILL_BUREAUCRACY	= SKILL_EXPERT,
+	                    SKILL_FINANCE		= SKILL_BASIC)
+	skill_points = 20
+	access = list(access_liaison, access_bridge, access_solgov_crew,
+						access_nanotrasen, access_commissary, access_torch_fax, access_science, access_maint_tunnels)
+	software_on_spawn = list(/datum/computer_file/program/reports)
+
+/datum/job/liaison/get_description_blurb()
+	return "You are the Workplace Liaison. You are a civilian employee of a Company that has invested into the NTSS Dagon. You are on board the vessel to promote corporate interests or protect the rights of the contractors on board as their union leader. You are not internal affairs. You advise command on corporate and union matters and contractors on their rights and obligations. Maximise profit. Be the shady corporate shill you always wanted to be."
+
+/datum/job/liaison/post_equip_rank(var/mob/person, var/alt_title)
+	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Executive Assistant")]"]"
+	for(var/mob/M in GLOB.player_list)
+		if(M.client && M.mind)
+			if(M.mind.assigned_role == "Executive Assistant")
+				to_chat(M, SPAN_NOTICE("<b>One of your employers, [my_title] named [person.real_name], is present on [GLOB.using_map.full_name].</b>"))
+	..()
+
+
+	//############# ASSET PROTECTION AGENT
+
+
+	/datum/job/bodyguard
+	title = "Executive Assistant"
+	department = "Support"
+	department_flag = SPT
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Workplace Liaison"
+	selection_color = "#3d3d7f"
+	economic_power = 12
+	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 19)
+	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/corporate_bodyguard
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_BASIC,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
+	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT,
+	                    SKILL_FORENSICS   = SKILL_EXPERT)
+	alt_titles = list(
+		"Union Enforcer",
+		"Loss Prevention Associate",
+		"Asset Protection Agent"
+	)
+	skill_points = 20
+	access = list(access_liaison, access_bridge, access_solgov_crew,
+						access_nanotrasen, access_commissary,
+						access_sec_guard, access_torch_fax, access_science, access_maint_tunnels)
+	defer_roundstart_spawn = TRUE
+
+/datum/job/bodyguard/is_position_available()
+	if(..())
+		for(var/mob/M in GLOB.player_list)
+			if(M.client && M.mind && M.mind.assigned_role == "Workplace Liaison")
+				return TRUE
+	return FALSE
+
+/datum/job/bodyguard/get_description_blurb()
+	return "You are the Executive Assistant. You are an employee of one of the corporations that make up the crew aboard the NTSS Dagon, and your job is to assist the Liason in corporate affairs. You are also expected to protect the Liason's life."
+
+/datum/job/bodyguard/post_equip_rank(var/mob/person, var/alt_title)
+	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Executive Assistant")]"]"
+	for(var/mob/M in GLOB.player_list)
+		if(M.client && M.mind)
+			if(M.mind.assigned_role == "Workplace Liaison")
+				to_chat(M, SPAN_NOTICE("<b>Your bodyguard, [my_title] named [person.real_name], is present on [GLOB.using_map.full_name].</b>"))
+	..()
+
+
+	//############# ENGINEERING
+	//############# SENIOR ENGINEER
+
+
+	/datum/job/senior_engineer
+	title = "Senior Engineer"
+	department = "Engineering"
+	department_flag = ENG
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Chief Engineer"
+	selection_color = "#5b4d20"
+	economic_power = 7
+	minimal_player_age = 3
+	minimum_character_age = list(SPECIES_HUMAN = 27)
+	ideal_character_age = 40
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e7,
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/fleet/e7,
+		/datum/mil_rank/fleet/e8,
+	)
+	min_skill = list(   SKILL_COMPUTER     = SKILL_BASIC,
+	                    SKILL_EVA          = SKILL_ADEPT,
+	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_ELECTRICAL   = SKILL_ADEPT,
+	                    SKILL_ATMOS        = SKILL_BASIC,
+	                    SKILL_ENGINES      = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
+	skill_points = 24
+
+	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
+			            access_tcomsat, access_solgov_crew, access_seneng, access_hangar, access_network)
+
+	software_on_spawn = list(/datum/computer_file/program/power_monitor,
+							 /datum/computer_file/program/supermatter_monitor,
+							 /datum/computer_file/program/alarm_monitor,
+							 /datum/computer_file/program/atmos_control,
+							 /datum/computer_file/program/rcon_console,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/shields_monitor)
+
+/datum/job/senior_engineer/get_description_blurb()
+	return "You are the Senior Engineer. You are a veteran Engineer. You are subordinate to the Chief Engineer though you may have many years more experience than them and your subordinates are the rest of engineering. You should be an expert in practically every engineering area and familiar and possess leadership skills. Coordinate the team and ensure the smooth running of the department along with the Chief Engineer."
+
+
+	//############# ENGINEER
+
+
+/datum/job/engineer
+	title = "Engineer"
+	total_positions = 6
+	spawn_positions = 6
+	supervisors = "the Chief Engineer"
+	economic_power = 5
+	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 19)
+	ideal_character_age = 30
+	alt_titles = list(
+		"Engine Technician",
+		"Damage Control Technician",
+		"Electrician",
+		"Atmospheric Technician",
+		)
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/ec/e5,
+		/datum/mil_rank/civ/contractor
+	)
+	min_skill = list(   SKILL_COMPUTER     = SKILL_BASIC,
+	                    SKILL_EVA          = SKILL_BASIC,
+	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_ELECTRICAL   = SKILL_BASIC,
+	                    SKILL_ATMOS        = SKILL_BASIC,
+	                    SKILL_ENGINES      = SKILL_BASIC)
+
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
+	skill_points = 20
+
+	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
+			            access_solgov_crew, access_hangar)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/power_monitor,
+							 /datum/computer_file/program/supermatter_monitor,
+							 /datum/computer_file/program/alarm_monitor,
+							 /datum/computer_file/program/atmos_control,
+							 /datum/computer_file/program/rcon_console,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/shields_monitor)
+
+/datum/job/engineer/get_description_blurb()
+	return "You are an Engineer. You operate under one of many titles and may be highly specialised in a specific area of engineering. You probably have at least a general familiarity with most other areas though this is not expected. You are subordinate to the Senior Engineer and the Chief Engineer and are expected to follow them."
+
+
+	//############# ENGINEER TRAINEE
+
+
+/datum/job/engineer_trainee
+	title = "Engineer Trainee"
+	department = "Engineering"
+	department_flag = ENG
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Chief Engineer and Engineering Personnel"
+	selection_color = "#5b4d20"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 20
+
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/fleet/e2
+	)
+
+	skill_points = 4
+	no_skill_buffs = TRUE
+
+	min_skill = list(   SKILL_COMPUTER     = SKILL_BASIC,
+	                    SKILL_HAULING      = SKILL_ADEPT,
+	                    SKILL_EVA          = SKILL_ADEPT,
+	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_ELECTRICAL   = SKILL_ADEPT,
+	                    SKILL_ATMOS        = SKILL_ADEPT,
+	                    SKILL_ENGINES      = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
+
+	access = list(access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_eva, access_tech_storage, access_janitor, access_construction,
+			            access_solgov_crew, access_hangar)
+
+	software_on_spawn = list(/datum/computer_file/program/power_monitor,
+							 /datum/computer_file/program/supermatter_monitor,
+							 /datum/computer_file/program/alarm_monitor,
+							 /datum/computer_file/program/atmos_control,
+							 /datum/computer_file/program/rcon_console,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/shields_monitor)
+
+/datum/job/engineer_trainee/get_description_blurb()
+	return "You are an Engineer Trainee. You are learning how to operate the various onboard engineering systems from senior engineering staff. You are subordinate to all of the other engineers aboard."
+
+
+	//############# EXPLORATION
+	//############# PATHFINDER
+
+
+/datum/job/pathfinder
+	title = "Pathfinder"
+	department = "Exploration"
+	department_flag = EXP
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Chief Science Officer"
+	selection_color = "#68099e"
+	minimal_player_age = 1
+	economic_power = 10
+	minimum_character_age = list(SPECIES_HUMAN = 25)
+	ideal_character_age = 35
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/pathfinder
+	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o1
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_ADEPT,
+	                    SKILL_SCIENCE     = SKILL_ADEPT,
+	                    SKILL_PILOT       = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX,
+	                    SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT)
+	skill_points = 22
+
+	access = list(
+		access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_bridge, access_emergency_storage,
+		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm,
+		access_guppy, access_hangar, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
+		access_petrov_toxins, access_petrov_chemistry, access_petrov_maint, access_tox, access_tox_storage, access_research,
+		access_xenobiology, access_xenoarch, access_torch_fax
+	)
+
+	software_on_spawn = list(/datum/computer_file/program/deck_management,
+							 /datum/computer_file/program/reports)
+
+/datum/job/pathfinder/get_description_blurb()
+	return "You are the Pathfinder. Your duty is to organize and lead the expeditions to away sites, carrying out the Primary Directive, Jupiter. You command Explorers. You make sure that expedition has the supplies and personnel it needs. You can pilot Gaunt if nobody else provides a pilot. Once on the away mission, your duty is to ensure that anything of scientific interest is brought back to the ship and passed to the relevant research lab."
+
+
+	//############# SHUTTLE PILOT
+
+
+/datum/job/nt_pilot
+	title = "Shuttle Pilot"
+	supervisors = "the Pathfinder"
+	department = "Exploration"
+	department_flag = EXP
+	total_positions = 1
+	spawn_positions = 1
+	selection_color = "#68099e"
+	economic_power = 8
+	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 24)
+	ideal_character_age = 25
+	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/pilot
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/expeditionary_corps = /decl/hierarchy/outfit/job/torch/crew/exploration/pilot,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/exploration/pilot/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/nt_pilot,
+		/datum/mil_rank/ec/e7,
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/fleet/e7
+	)
+
+	access = list(
+		access_mining_office, access_petrov, access_petrov_helm, access_petrov_maint, access_mining_station,
+		access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm,
+		access_mining, access_pilot, access_solgov_crew, access_eva, access_explorer, access_research
+	)
+	min_skill = list(	SKILL_EVA   = SKILL_BASIC,
+						SKILL_PILOT = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
+
+
+	//############# EXPLORER
+
+
+/datum/job/explorer
+	title = "Explorer"
+	department = "Exploration"
+	department_flag = EXP
+	total_positions = 5
+	spawn_positions = 5
+	supervisors = "the Commanding Officer, Executive Officer, and Pathfinder"
+	selection_color = "#68099e"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 20
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/explorer
+	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
+
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/ec/e5
+	)
+	min_skill = list(   SKILL_EVA = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX,
+	                    SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT)
+
+	access = list(access_explorer, access_maint_tunnels, access_eva, access_emergency_storage,
+		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
+		access_petrov, access_petrov_maint, access_research
+	)
+
+	software_on_spawn = list(/datum/computer_file/program/deck_management)
+
+/datum/job/explorer/get_description_blurb()
+	return "You are an Explorer. Your duty is to go on expeditions to away sites. The Pathfinder is your team leader. You are to look for anything of economic or scientific interest to NanoTrasen - mineral deposits, alien flora/fauna, artifacts. You will also likely encounter hazardous environments, aggressive wildlife or malfunctioning defense systems, so tread carefully."
+
+
+	//############# MEDICAL
+	//############# PHYSICIAN
+
+
+/datum/job/senior_doctor
+	title = "Physician"
+	department = "Medical"
+	department_flag = MED
+	minimal_player_age = 2
+	minimum_character_age = list(SPECIES_HUMAN = 29)
+	ideal_character_age = 45
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Chief Medical Officer"
+	selection_color = "#013d3b"
+	economic_power = 10
+	alt_titles = list(
+		"Surgeon")
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/senior
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/senior/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/senior
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o1,
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/civ/contractor
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_EXPERT,
+	                    SKILL_CHEMISTRY   = SKILL_BASIC,
+						SKILL_DEVICES     = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	skill_points = 20
+
+	access = list(access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
+			            access_crematorium, access_chemistry, access_surgery,
+			            access_medical_equip, access_solgov_crew, access_senmed, access_hangar)
+
+	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/camera_monitor)
+
+
+	//############# MEDICAL RESIDENT
+
+
+/datum/job/junior_doctor
+	title = "Medical Resident"
+	department = "Medical"
+	department_flag = MED
+	minimal_player_age = 2
+	minimum_character_age = list(SPECIES_HUMAN = 24)
+	ideal_character_age = 45
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "Physicians and the Chief Medical Officer"
+	selection_color = "#013d3b"
+	economic_power = 6
+	alt_titles = list(
+		"Nurse")
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/senior
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/senior/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/senior
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o1,
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/civ/contractor
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_EXPERT,
+	                    SKILL_CHEMISTRY   = SKILL_BASIC,
+						SKILL_DEVICES     = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	skill_points = 16
+
+	access = list(access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
+			            access_crematorium, access_chemistry, access_surgery,
+			            access_medical_equip, access_solgov_crew, access_senmed, access_hangar)
+
+	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/camera_monitor)
+
+
+	//############# MEDICAL TECHNICIAN
+
+
+/datum/job/doctor
+	title = "Medical Technician"
+	total_positions = 3
+	spawn_positions = 3
+	supervisors = "Physicians and the Chief Medical Officer"
+	economic_power = 7
+	minimum_character_age = list(SPECIES_HUMAN = 19)
+	ideal_character_age = 40
+	minimal_player_age = 0
+	alt_titles = list(
+		"Paramedic",
+		"Corpsman")
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/doctor
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/doctor/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/ec/e5,
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/civ/contractor
+	)
+	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
+	                    SKILL_MEDICAL = SKILL_BASIC,
+	                    SKILL_ANATOMY = SKILL_BASIC)
+
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX)
+
+	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_eva, access_surgery, access_medical_equip, access_solgov_crew, access_hangar)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/camera_monitor)
+	skill_points = 22
+
+
+	//############# TRAINEE MEDICAL TECHNICIAN
+
+
+/datum/job/medical_trainee
+	title = "Trainee Medical Technician"
+	department = "Medical"
+	department_flag = MED
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "Medical personnel, and the Chief Medical Officer"
+	selection_color = "#013d3b"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 20
+	alt_titles = list(
+		"Corpsman Trainee")
+
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/doctor
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/doctor/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/fleet/e2
+	)
+
+	skill_points = 16
+	no_skill_buffs = TRUE
+
+	min_skill = list(   SKILL_EVA     = SKILL_ADEPT,
+	                    SKILL_HAULING = SKILL_ADEPT,
+	                    SKILL_MEDICAL = SKILL_BASIC,
+	                    SKILL_ANATOMY = SKILL_BASIC)
+
+	max_skill = list(   SKILL_MEDICAL     = SKILL_ADEPT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_CHEMISTRY   = SKILL_ADEPT)
+
+	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_surgery, access_medical_equip, access_solgov_crew, access_hangar)
+
+	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/camera_monitor)
+
+/datum/job/medical_trainee/get_description_blurb()
+	return "You are a Trainee Medical Technician. You are learning how to treat and recover wounded crew from the more experienced medical personnel aboard. You are subordinate to the rest of the medical team."
+
+
+	//############# LABORATORY TECHNICIAN
+
+
+/datum/job/chemist
+	title = "Laboratory Technician"
+	department = "Medical"
+	department_flag = MED
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Chief Medical Officer, the Corporate Liaison and Medical Personnel"
+	selection_color = "#013d3b"
+	economic_power = 4
+	minimum_character_age = list(SPECIES_HUMAN = 25)
+	ideal_character_age = 30
+	minimal_player_age = 7
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	min_skill = list(   SKILL_MEDICAL   = SKILL_BASIC,
+	                    SKILL_CHEMISTRY = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_MEDICAL     = SKILL_BASIC,
+						SKILL_ANATOMY	  = SKILL_BASIC,
+	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	skill_points = 16
+
+	access = list(access_medical, access_maint_tunnels, access_emergency_storage, access_medical_equip, access_solgov_crew, access_chemistry,
+	 						access_virology, access_morgue, access_crematorium, access_hangar)
+	minimal_access = list()
+
+/datum/job/chemist/get_description_blurb()
+	return "You are a Laboratory Technician. You make medicine. You are not a doctor or medic, but have surface level knowledge in those fields. You should not be treating patients, but rather providing the the medicine to do so. You are subordinate to Physicians and Medical Techncians."
+
+
+	//############# COUNSELOR
+
+
+/datum/job/psychiatrist
+	title = "Counselor"
+	total_positions = 1
+	spawn_positions = 1
+	ideal_character_age = 40
+	economic_power = 5
+	minimum_character_age = list(SPECIES_HUMAN = 24)
+	minimal_player_age = 0
+	supervisors = "the Chief Medical Officer"
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/counselor
+	alt_titles = list(
+		"Psychiatrist",
+		"Psionic Counselor" = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/mentalist,
+		"Mentalist" = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/mentalist
+
+	)
+
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/expeditionary_corps = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/ec,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/fleet)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/ec/o1)
+	min_skill = list(
+		SKILL_BUREAUCRACY = SKILL_BASIC,
+		SKILL_MEDICAL     = SKILL_BASIC
+	)
+	max_skill = list(
+		SKILL_MEDICAL     = SKILL_MAX
+	)
+	access = list(access_medical, access_psychiatrist, access_solgov_crew, access_medical_equip, access_hangar, access_maint_tunnels)
+	minimal_access = list()
+	software_on_spawn = list(
+		/datum/computer_file/program/suit_sensors,
+		/datum/computer_file/program/camera_monitor
+	)
+	give_psionic_implant_on_join = FALSE
+
+/datum/job/psychiatrist/equip(var/mob/living/carbon/human/H)
+	if(H.mind.role_alt_title == "Psionic Counselor")
+		psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT)
+	if(H.mind.role_alt_title == "Mentalist")
+		psi_faculties = list("[PSI_COERCION]" = PSI_RANK_OPERANT)
+	return ..()
+
+
+/datum/job/psychiatrist/get_description_blurb()
+		return "You are the Counselor. Your main responsibility is the mental health and wellbeing of the crew. You are subordinate to the Chief Medical Officer."
+
+
+		//############# RESEARCH
+		//############# SENIOR RESEARCHER
+
+
+/datum/job/senior_scientist
+	title = "Senior Researcher"
+	department = "Science"
+	department_flag = SCI
+
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Chief Science Officer"
+	selection_color = "#633d63"
+	economic_power = 12
+	minimal_player_age = 3
+	minimum_character_age = list(SPECIES_HUMAN = 30)
+	ideal_character_age = 50
+	alt_titles = list(
+		"Research Supervisor")
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/senior_scientist
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o1
+	)
+
+	access = list(access_tox, access_tox_storage, access_maint_tunnels, access_research, access_mining_office,
+						access_mining_station, access_xenobiology, access_xenoarch, access_nanotrasen, access_solgov_crew,
+						access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
+						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_security,
+						access_petrov_maint, access_torch_fax, access_robotics)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_FINANCE     = SKILL_BASIC,
+	                    SKILL_BOTANY      = SKILL_BASIC,
+	                    SKILL_ANATOMY     = SKILL_BASIC,
+	                    SKILL_DEVICES     = SKILL_ADEPT,
+	                    SKILL_SCIENCE     = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
+	skill_points = 20
+
+
+	//############# SCIENTIST
+
+
+/datum/job/scientist
+	title = "Scientist"
+	total_positions = 6
+	spawn_positions = 6
+	supervisors = "the Chief Science Officer"
+	economic_power = 10
+	minimum_character_age = list(SPECIES_HUMAN = 25)
+	ideal_character_age = 45
+	minimal_player_age = 0
+	alt_titles = list(
+		"Xenoarcheologist",
+		"Anomalist",
+		"Researcher",
+		"Xenobiologist",
+		"Xenobotanist"
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_DEVICES     = SKILL_BASIC,
+	                    SKILL_SCIENCE     = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
+
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/scientist
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/solgov,
+		/datum/mil_branch/expeditionary_corps
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o1,
+		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/scientist,
+		/datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/solgov
+	)
+
+	access = list(access_tox, access_tox_storage, access_research, access_petrov, access_petrov_helm,
+						access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
+						access_xenoarch, access_nanotrasen, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
+						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_torch_fax, access_petrov_maint,
+						access_maint_tunnels, access_robotics)
+	minimal_access = list()
+	skill_points = 20
+
+
+		//############# RESEARCH ASSISTANT
+
+
+/datum/job/scientist_assistant
+	title = "Research Assistant"
+	department = "Science"
+	department_flag = SCI
+	total_positions = 4
+	spawn_positions = 4
+	supervisors = "the Chief Science Officer and science personnel"
+	selection_color = "#633d63"
+	economic_power = 3
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 30
+	alt_titles = list(
+		"Custodian" = /decl/hierarchy/outfit/job/torch/passenger/research/assist/janitor,
+		"Testing Assistant" = /decl/hierarchy/outfit/job/torch/passenger/research/assist/testsubject,
+		"Intern",
+		"Clerk",
+		"Field Assistant")
+
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/solgov,
+		/datum/mil_branch/expeditionary_corps
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/ec/e5,
+		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/assist,
+		/datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/assist/solgov
+	)
+	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
+
+	access = list(access_tox, access_tox_storage, access_research, access_petrov,
+						access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
+						access_xenoarch, access_nanotrasen, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
+						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry,
+						access_maint_tunnels, access_robotics)
+
+
+		//############# ROBOTICIST
+
 
 /datum/job/roboticist
 	title = "Roboticist"
@@ -351,5 +1531,544 @@ var/const/INF               =(1<<11)
 	                    SKILL_ANATOMY      = SKILL_EXPERT)
 	skill_points = 20
 
-	access = list(access_maint_tunnels, access_research, access_robotics, access_nanotrasen, access_solgov_crew, access_surgery, access_medical)
+	access = list(access_maint_tunnels, access_research, access_robotics,
+	              access_nanotrasen, access_solgov_crew, access_surgery, access_medical, access_hangar)
 	minimal_access = list()
+
+
+		//############# SECURITY
+		//############# BRIG CHIEF
+
+
+/datum/job/warden
+	title = "Brig Chief"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Chief of Security"
+	economic_power = 5
+	minimal_player_age = 7
+	ideal_character_age = 35
+	minimum_character_age = list(SPECIES_HUMAN = 27)
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/brig_chief
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/security/brig_chief/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e7,
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/fleet/e7,
+		/datum/mil_rank/fleet/e8,
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
+
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_MAX)
+	skill_points = 20
+
+	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
+			            access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_eva, access_sec_doors, access_solgov_crew, access_gun, access_torch_fax)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
+							 /datum/computer_file/program/camera_monitor)
+
+
+		//############# FORENSICS TECHNICIAN
+
+
+/datum/job/detective
+	title = "Forensic Technician"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Chief of Security"
+	economic_power = 5
+	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 25)
+	ideal_character_age = 35
+	skill_points = 14
+	alt_titles = list(
+		"Criminal Investigator"
+	)
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/contractor,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/fleet,
+		/datum/mil_branch/solgov = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/agent
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/ec/e5,
+		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/sol/agent
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_BASIC,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
+
+	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT,
+	                    SKILL_FORENSICS   = SKILL_MAX)
+	skill_points = 20
+
+	access = list(access_security, access_brig, access_forensics_lockers,
+			            access_maint_tunnels, access_emergency_storage,
+			            access_sec_doors, access_solgov_crew, access_morgue,
+			            access_torch_fax)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
+							 /datum/computer_file/program/camera_monitor)
+
+
+		//############# MASTER AT ARMS
+
+
+/datum/job/officer
+	title = "Master at Arms"
+	total_positions = 4
+	spawn_positions = 4
+	supervisors = "the Chief of Security"
+	economic_power = 4
+	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 25
+	alt_titles = list() // This is a hack. Overriding a list var with null does not actually override it due to the particulars of dm list init. Do not "clean up" without testing.
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/maa
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/security/maa/fleet,
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/fleet/e4,
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
+
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_EXPERT)
+
+	access = list(access_security, access_brig, access_maint_tunnels,
+						access_external_airlocks, access_emergency_storage,
+			            access_eva, access_sec_doors, access_solgov_crew)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
+							 /datum/computer_file/program/camera_monitor)
+
+
+		//############# SECURITY CADET
+
+
+/datum/job/seccadet
+	title = "Security Cadet"
+	department = "Security"
+	department_flag = SEC
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the entirety of Security"
+	economic_power = 1
+	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	selection_color = "#601c1c"
+	alt_titles = list(
+		"Forensics Trainee"
+		)
+	min_skill = list(   SKILL_EVA         = SKILL_ADEPT,
+	                    SKILL_COMBAT      = SKILL_BASIC)
+	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT,
+	                    SKILL_FORENSICS   = SKILL_EXPERT)
+	skill_points = 16
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/maa
+	allowed_branches = list(
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/security/maa/fleet,
+		/datum/mil_branch/marine_corps
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/fleet/e2,
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/marine_corps/e2,
+		/datum/mil_rank/marine_corps/e3
+	)
+	access = list(access_security, access_brig, access_maint_tunnels,
+						access_external_airlocks, access_emergency_storage,
+			            access_eva, access_sec_doors, access_solgov_crew)
+	minimal_access = list()
+	software_on_spawn = list(/datum/computer_file/program/digitalwarrant)
+
+/datum/job/seccadet/get_description_blurb()
+	return "You're either a new hire, or a new trainee aboard the [GLOB.using_map.full_name]. Everyone is your senior, and as such, you'd best listen to them."
+
+
+		//############# SUPPLY
+		//############# DECK CHIEF
+
+
+/datum/job/qm
+	title = "Deck Chief"
+	department = "Supply"
+	department_flag = SUP
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Executive Officer"
+	economic_power = 5
+	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 27)
+	ideal_character_age = 35
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/ec/e7,
+		/datum/mil_rank/fleet/e7,
+		/datum/mil_rank/fleet/e8
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_FINANCE     = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_PILOT       = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+	skill_points = 18
+
+	access = list(access_maint_tunnels, access_bridge, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
+						access_cargo_bot, access_qm, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
+						access_mining, access_mining_office, access_mining_station, access_commissary, access_teleporter, access_eva, access_torch_fax)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/supply,
+							 /datum/computer_file/program/deck_management,
+							 /datum/computer_file/program/reports)
+
+
+		//############# DECK TECHNICIAN
+
+
+/datum/job/cargo_tech
+	title = "Deck Technician"
+	department = "Supply"
+	department_flag = SUP
+	total_positions = 3
+	spawn_positions = 3
+	supervisors = "the Deck Chief and Executive Officer"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 24
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/tech
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/supply/tech/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/supply/contractor
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/fleet/e2,
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/civ/contractor
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_FINANCE     = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+
+	access = list(access_maint_tunnels, access_emergency_storage, access_cargo, access_guppy_helm,
+						access_cargo_bot, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_commissary)
+	minimal_access = list()
+
+	software_on_spawn = list(/datum/computer_file/program/supply,
+							 /datum/computer_file/program/deck_management,
+							 /datum/computer_file/program/reports)
+
+
+	//############# PROSPECTOR
+
+
+/datum/job/mining
+	title = "Prospector"
+	department = "Supply"
+	department_flag = SUP
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Deck Chief and the Executive Officer"
+	economic_power = 7
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 25
+	alt_titles = list(
+		"Drill Technician",
+		"Shaft Miner",
+		"Salvage Technician")
+	min_skill = list(   SKILL_HAULING = SKILL_ADEPT,
+	                    SKILL_EVA     = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+
+	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/prospector
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+
+	access = list(access_mining, access_mining_office, access_mining_station,
+						access_expedition_shuttle, access_guppy, access_hangar, access_guppy_helm, access_solgov_crew, access_eva)
+	minimal_access = list()
+
+
+	//############# SERVICE
+	//############# CHAPLAIN
+
+
+/datum/job/chaplain
+	title = "Chaplain"
+	department = "Service"
+	department_flag = SRV
+	total_positions = 1
+	spawn_positions = 1
+	minimum_character_age = list(SPECIES_HUMAN = 24)
+	ideal_character_age = 40
+	economic_power = 6
+	minimal_player_age = 0
+	supervisors = "the Executive Officer"
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/chaplain
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/expeditionary_corps = /decl/hierarchy/outfit/job/torch/crew/service/chaplain/ec,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/service/chaplain/fleet)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/ec/o1)
+	min_skill = list(SKILL_BUREAUCRACY = SKILL_BASIC)
+	access = list(access_morgue, access_chapel_office, access_crematorium, access_solgov_crew)
+	minimal_access = list()
+
+
+	//############# SANITATION TECH
+
+
+/datum/job/janitor
+	title = "Sanitation Technician"
+	department = "Service"
+	department_flag = SRV
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Executive Officer"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 20
+	alt_titles = list(
+		"Janitor")
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/janitor
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/expeditionary_corps = /decl/hierarchy/outfit/job/torch/crew/service/janitor/ec,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/service/janitor/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/fleet/e2,
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/fleet/e4
+	)
+	min_skill = list(   SKILL_HAULING = SKILL_BASIC)
+
+	access = list(access_maint_tunnels, access_emergency_storage, access_janitor, access_solgov_crew)
+	minimal_access = list()
+
+
+	//############# COOK
+
+
+/datum/job/chef
+	title = "Cook"
+	department = "Service"
+	department_flag = SRV
+	total_positions = 1
+	spawn_positions = 1
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	supervisors = "the Executive Officer"
+	alt_titles = list(
+		"Chef",
+		"Culinary Specialist"
+		)
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/cook
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/expeditionary_corps = /decl/hierarchy/outfit/job/torch/crew/service/cook/ec,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/service/cook/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/fleet/e2,
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/fleet/e4
+	)
+	min_skill = list(   SKILL_COOKING   = SKILL_ADEPT,
+	                    SKILL_BOTANY    = SKILL_BASIC,
+	                    SKILL_CHEMISTRY = SKILL_BASIC)
+	access = list(access_hydroponics, access_kitchen, access_solgov_crew, access_bar, access_commissary)
+	minimal_access = list()
+
+
+	//############# BARTENDER
+
+
+/datum/job/bartender
+	department = "Service"
+	department_flag = SRV
+	supervisors = "the Executive Officer and the Corporate Liaison"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 30
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/bartender
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+
+	access = list(access_hydroponics, access_bar, access_solgov_crew, access_kitchen, access_commissary)
+	minimal_access = list()
+	min_skill = list(   SKILL_COOKING   = SKILL_BASIC,
+	                    SKILL_BOTANY    = SKILL_BASIC,
+	                    SKILL_CHEMISTRY = SKILL_BASIC)
+
+
+	//############# CREWMAN
+
+
+/datum/job/crew
+	title = "Crewman"
+	department = "Service"
+	department_flag = SRV
+	total_positions = 5
+	spawn_positions = 5
+	supervisors = "the Executive Officer, NTEF and SMC Personnel"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
+	ideal_character_age = 20
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/crewman
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/service/crewman/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/fleet/e2,
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/fleet/e4
+	)
+
+	access = list(access_maint_tunnels, access_emergency_storage, access_solgov_crew)
+
+
+	//############# SILICON
+	//############# CYBORG
+
+
+/datum/job/cyborg
+	total_positions = 3
+	spawn_positions = 3
+	supervisors = "your laws"
+	minimal_player_age = 3
+	allowed_ranks = list(
+		/datum/mil_rank/civ/synthetic
+	)
+
+
+	//############# AI
+
+
+/datum/job/ai
+	//minimal_player_age = 7
+	minimal_player_age = 0 //TEMPORARY. FOR DEBUG REASONS
+	allowed_ranks = list(
+		/datum/mil_rank/civ/synthetic
+	)
+
+
+	//############# MISC JOBS
+	//############# PASSENGER
+
+
+/datum/job/assistant
+	title = "Passenger"
+	total_positions = 12
+	spawn_positions = 12
+	supervisors = "the Executive Officer"
+	economic_power = 6
+	announced = FALSE
+	alt_titles = list(
+		"Journalist" = /decl/hierarchy/outfit/job/torch/passenger/passenger/journalist,
+		"Historian",
+		"Assistant",
+		"Off-Duty",
+		"Botanist",
+		"Investor" = /decl/hierarchy/outfit/job/torch/passenger/passenger/investor,
+		"Psychologist" = /decl/hierarchy/outfit/job/torch/passenger/passenger/psychologist,
+		"Naturalist",
+		"Ecologist",
+		"Entertainer",
+		"Independent Observer",
+		"Sociologist",
+		"Trainer")
+	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/passenger
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/civ,
+		/datum/mil_rank/civ/contractor
+	)
+
+
+	//############# MERCHANT
+
+
+/datum/job/merchant
+	title = "Merchant"
+	department = "Civilian"
+	department_flag = CIV
+	total_positions = 2
+	spawn_positions = 2
+	availablity_chance = 30
+	supervisors = "the invisible hand of the market"
+	ideal_character_age = 30
+	minimal_player_age = 0
+	create_record = 0
+	outfit_type = /decl/hierarchy/outfit/job/torch/merchant
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/alien
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/civ,
+		/datum/mil_rank/alien
+	)
+	latejoin_at_spawnpoints = 1
+	access = list(access_merchant)
+	announced = FALSE
+	min_skill = list(   SKILL_FINANCE = SKILL_ADEPT,
+	                    SKILL_PILOT	  = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+	skill_points = 24
+	required_language = null
+	give_psionic_implant_on_join = FALSE

--- a/modular_boh/loadouts/custom_loadouts.dm
+++ b/modular_boh/loadouts/custom_loadouts.dm
@@ -51,7 +51,7 @@
 #define RESEARCH_ROLES list(/datum/job/rd, /datum/job/scientist, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/assistant, /datum/job/nt_pilot, /datum/job/senior_scientist, /datum/job/roboticist, /datum/job/psiadvisor)
 
 //For jobs that spawn with weapons in their lockers //## VESTA.BAY # ADDED /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead, /datum/job/seccadet
-#define ARMED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/bodyguard, /datum/job/submap/CTI_pilot, /datum/job/submap/CTI_engineer, /datum/job/submap/scavver_pilot, /datum/job/submap/scavver_doctor, /datum/job/submap/scavver_engineer, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead, /datum/job/seccadet)
+#define ARMED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/officer, /datum/job/psiadvisor, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/bodyguard, /datum/job/submap/CTI_pilot, /datum/job/submap/CTI_engineer, /datum/job/submap/scavver_pilot, /datum/job/submap/scavver_doctor, /datum/job/submap/scavver_engineer, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead, /datum/job/seccadet)
 
 //For jobs that spawn with armor in their lockers	//## VESTA.BAY # ADDED /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead, /datum/job/seccadet
 #define ARMORED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/qm, /datum/job/sea, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/submap/skrellscoutship_crew, /datum/job/submap/skrellscoutship_crew/leader, /datum/job/submap/scavver_pilot, /datum/job/submap/scavver_doctor, /datum/job/submap/scavver_engineer, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead, /datum/job/seccadet)
@@ -60,7 +60,7 @@
 
 #define CIVILIAN_BRANCHES list(/datum/mil_branch/civilian, /datum/mil_branch/solgov)
 
-#define SOLGOV_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov)
+#define SOLGOV_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov, /datum/mil_branch/marine_corps)
 
 #define NT_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet)
 //#### These two for code uniformity####//
@@ -451,7 +451,7 @@ datum/gear/head/ECdepartment/New()
 /datum/gear/head/corpsecberet
 	display_name = "Corporate security beret"
 	path = /obj/item/clothing/head/beret/guard
-	allowed_branches = SECURITY_COMPANY_BRANCHES
+	allowed_branches = SECURITY_COMPANY_BRANCHES, TACTICOOL_BRANCHES
 
 //################# AUGMENTS ###############################
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

- Added maintenance and robotics access to Science staff
- Hangar access added to Medical staff
- Trained Science minimum re-added to Bridge Officers
- Psi Advisors fixed to be able to take holsters during loadout
- Fixed SAARE/PCRC APA incapable of getting SAARE/PCRC Beret
- Added maintenance and research access to Liason/APA
- Fixed IPCs not being able to choose bald hair option
- Fixed Fleet being unable to get skill badges
- Made all webbings/drop pouches accessible in loadout to all roles again
- Gave Bridge Officers access to their Bridge Arm Lockers again
- Gave SMC their helmet covers back