### PR TITLE
Modularly adds the possibility to equip backpacks to suit_storage when wearing a deployed rig

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3187,6 +3187,7 @@
 #include "modular_boh\code\game\machinery\padv.dm"
 #include "modular_boh\code\game\machinery\resleever.dm"
 #include "modular_boh\code\items\documents.dm"
+#include "modular_boh\code\items\items.dm"
 #include "modular_boh\code\items\medical.dm"
 #include "modular_boh\code\items\storage.dm"
 #include "modular_boh\code\items\clothing\boh_accessory.dm"

--- a/modular_boh/code/items/items.dm
+++ b/modular_boh/code/items/items.dm
@@ -1,0 +1,6 @@
+/obj/item/weapon/storage/backpack/mob_can_equip(mob/living/carbon/human/H, slot, disable_warning = 0, force = 0)
+	if(istype(H.back, /obj/item/weapon/rig))
+		if(istype(H.wear_suit, /obj/item/clothing/suit/space/rig))
+			if(slot == slot_s_store)
+				return 1
+	return ..()


### PR DESCRIPTION
+ Modularly adds the possibility to equip backpacks to suit_storage when wearing a deployed rig

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->