### PR TITLE
Major Psionics Fix

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -50,8 +50,8 @@
 	var/defer_roundstart_spawn = FALSE // If true, the job will be put off until all other jobs have been populated.
 	var/list/species_branch_rank_cache_ = list()
 	var/list/psi_faculties                // Starting psi faculties, if any.
-	var/psi_latency_chance = 0            // Chance of an additional psi latency, if any.
-	var/give_psionic_implant_on_join = TRUE // If psionic, will be implanted for control.
+	var/psi_latency_chance = 5            // Chance of an additional psi latency, if any.
+	var/give_psionic_implant_on_join = FALSE // If psionic, will be implanted for control.
 
 	var/required_language
 

--- a/code/modules/psionics/mob/mob.dm
+++ b/code/modules/psionics/mob/mob.dm
@@ -13,9 +13,9 @@
 	. = ..()
 
 /mob/living/proc/set_psi_rank(var/faculty, var/rank, var/take_larger, var/defer_update, var/temporary)
-	if(!src.zone_sel)
+/*	if(!src.zone_sel) // VESTA.BAY @r4iser - Poorly treated Baystation12 change, blocking Mule and mostly all psionics
 		to_chat(src, SPAN_NOTICE("You feel something strange brush against your mind... but your brain is not able to grasp it."))
-		return
+		return*/
 	if(!psi)
 		psi = new(src)
 	var/current_rank = psi.get_rank(faculty)

--- a/html/changelogs/r4iser-PR-122.yml
+++ b/html/changelogs/r4iser-PR-122.yml
@@ -1,0 +1,7 @@
+author: Peekaboom
+
+delete-after: True
+
+changes: 
+  - tweak: "Increased all players psionics changes to 5%."
+  - bugfix: "Fixed bug stoppping psionics latents to be latents."


### PR DESCRIPTION
 + Fix Mules not spawning with psionics

 + Equalizes Rebayse psionics to old Vesta(odds and not being implanted by join)

fix #103 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->