### PR TITLE
Removes GAS, Diona, Adherents from antagonist roles.

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -4,7 +4,8 @@
 	var/list/restricted_jobs = 		list()   // Jobs that cannot be this antagonist at roundstart (depending on config)
 	var/list/protected_jobs = 		list()   // As above.
 	var/list/blacklisted_jobs =		list(/datum/job/submap)   // Jobs that can NEVER be this antagonist
-
+	var/list/blacklisted_species =   list(SPECIES_ADHERENT, SPECIES_DIONA, SPECIES_NABBER)
+	
 	// Strings.
 	var/welcome_text = "Cry havoc and let slip the dogs of war!"
 	var/leader_welcome_text                 // Text shown to the leader, if any.

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -6,7 +6,7 @@
 		if(player.current.faction != MOB_FACTION_NEUTRAL)
 			return 0
 
-	if(is_type_in_list(player.assigned_job, blacklisted_jobs))
+	if(is_type_in_list(player.assigned_job, blacklisted_jobs) || is_type_in_list(player.current.get_species(), blacklisted_species))
 		return 0
 
 	if(!ignore_role)

--- a/html/changelogs/torque4607-PR-134.yml
+++ b/html/changelogs/torque4607-PR-134.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Torque4607
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Puts a mining drill and braces aboard the seedship. The purples can go mining on planets now. Adds a few mantid lamps around. Helps in navigating around the place."
+  - maptweak: "Scatters some spare mantid power cells around the place, by popular request."
+  - rscadd: "Re-adds the medicine dispenser onto the Ascent seedship. It was on old!Hestia's seedship."
+

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -4425,6 +4425,15 @@
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/hydroponics_starboard)
+"pk" = (
+/obj/machinery/ion_engine{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/hydroponics_port)
 "pp" = (
 /obj/structure/table/rack/dark,
 /obj/item/clothing/suit/space/void/ascent,
@@ -4472,8 +4481,9 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "qc" = (
-/turf/space,
-/area/ship/ascent/aft_starboard_jut)
+/obj/machinery/mining/brace,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/fore_starboard_prow)
 "qG" = (
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
@@ -4916,6 +4926,8 @@
 /obj/item/weapon/pickaxe/diamonddrill/ascent,
 /obj/item/weapon/pickaxe/diamonddrill/ascent,
 /obj/item/weapon/pickaxe/diamonddrill/ascent,
+/obj/item/device/flashlight/lamp/floodlamp/ascent,
+/obj/item/device/flashlight/lamp/floodlamp/ascent,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "Fd" = (
@@ -5431,6 +5443,10 @@
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
+"WJ" = (
+/obj/machinery/mining/drill,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/fore_starboard_prow)
 "Xa" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
@@ -11915,7 +11931,7 @@ ah
 as
 as
 Ap
-as
+qc
 bz
 pp
 bt
@@ -12037,7 +12053,7 @@ Kh
 lb
 lb
 mn
-as
+qc
 hm
 Vr
 br
@@ -12159,7 +12175,7 @@ ah
 as
 as
 as
-as
+WJ
 bz
 lG
 br
@@ -14589,7 +14605,7 @@ aa
 aa
 aa
 aa
-qc
+aa
 XG
 FO
 tr
@@ -14858,8 +14874,8 @@ dc
 bQ
 hy
 bW
-aa
-aa
+Aj
+Aj
 aa
 aa
 aa
@@ -14980,9 +14996,9 @@ dd
 dU
 bW
 bW
-aa
-aa
-aa
+Aj
+Aj
+Aj
 aa
 aa
 aa
@@ -15102,9 +15118,9 @@ cD
 Av
 ng
 Aj
-aa
-aa
-aa
+Aj
+Aj
+Aj
 aa
 aa
 aa
@@ -15224,9 +15240,9 @@ cX
 Av
 Js
 Aj
-aa
-aa
-aa
+pk
+pk
+pk
 aa
 aa
 aa
@@ -16181,8 +16197,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+ha
+kq
 kq
 dz
 gc
@@ -16198,8 +16214,8 @@ Aj
 jm
 gf
 Aj
-aa
-aa
+kq
+ha
 aa
 aa
 aa
@@ -16304,7 +16320,7 @@ aa
 aa
 aa
 aa
-aa
+ha
 kq
 fZ
 gc
@@ -16320,7 +16336,7 @@ Aj
 jm
 iK
 Aj
-aa
+ha
 aa
 aa
 aa

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -1337,6 +1337,7 @@
 /area/ship/ascent/engineering)
 "dw" = (
 /obj/structure/table/steel_reinforced,
+/obj/item/weapon/cell/mantid,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/wing_starboard)
 "dx" = (
@@ -4702,6 +4703,15 @@
 /obj/machinery/portable_atmospherics/canister/methyl_bromide,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
+"xN" = (
+/obj/structure/table/rack/dark,
+/obj/item/clustertool,
+/obj/item/clustertool,
+/obj/item/clustertool,
+/obj/item/weapon/cell/mantid,
+/obj/item/weapon/cell/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/engineering)
 "yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4740,6 +4750,8 @@
 /obj/item/weapon/tank/mantid/reactor/oxygen,
 /obj/item/weapon/tank/mantid/reactor/oxygen,
 /obj/item/weapon/tank/mantid/reactor/oxygen,
+/obj/item/weapon/cell/mantid,
+/obj/item/weapon/cell/mantid,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/habitation)
 "zA" = (
@@ -5403,6 +5415,8 @@
 /obj/item/weapon/tank/mantid/reactor,
 /obj/item/weapon/tank/mantid/reactor,
 /obj/item/weapon/tank/mantid/reactor,
+/obj/item/weapon/cell/mantid,
+/obj/item/weapon/cell/mantid,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/habitation)
 "Vx" = (
@@ -15593,7 +15607,7 @@ dS
 hL
 gb
 cV
-hA
+xN
 dy
 dK
 eD

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -168,6 +168,9 @@
 /obj/machinery/light/ascent{
 	dir = 8
 	},
+/obj/machinery/chemical_dispenser/ert{
+	color = "PURPLE"
+	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "aH" = (
@@ -4532,6 +4535,15 @@
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
+"si" = (
+/obj/structure/table/rack/dark,
+/obj/item/clustertool,
+/obj/item/clustertool,
+/obj/item/clustertool,
+/obj/item/weapon/cell/mantid,
+/obj/item/weapon/cell/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/engineering)
 "sF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -4703,15 +4715,6 @@
 /obj/machinery/portable_atmospherics/canister/methyl_bromide,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
-"xN" = (
-/obj/structure/table/rack/dark,
-/obj/item/clustertool,
-/obj/item/clustertool,
-/obj/item/clustertool,
-/obj/item/weapon/cell/mantid,
-/obj/item/weapon/cell/mantid,
-/turf/simulated/floor/ascent,
-/area/ship/ascent/engineering)
 "yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4824,6 +4827,7 @@
 	name = "materials distributor";
 	output_turf = 2
 	},
+/obj/item/weapon/cell/mantid,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "Bz" = (
@@ -5443,6 +5447,26 @@
 /obj/machinery/computer/ship/sensors/ascent{
 	dir = 1
 	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/bridge)
+"VI" = (
+/obj/machinery/door/airlock/ascent,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/ascent,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/item/weapon/cell/mantid,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/bridge)
 "VR" = (
@@ -12925,7 +12949,7 @@ bb
 bb
 az
 az
-bO
+VI
 az
 bO
 az
@@ -15607,7 +15631,7 @@ dS
 hL
 gb
 cV
-xN
+si
 dy
 dK
 eD


### PR DESCRIPTION
## About The Pull Request

This is just a short fix that removes the three species that shouldn't be antags, from being able to _be_ antags. 

## Why It's Good For The Game

Firstly, these species are balance _nightmares_ and generate a metric ton of salt afterwards. Secondly, it's also a lore thing that these wouldn't be antagonists.

## Changelog
```changelog
tweak: removed gas, diona, adherents from being able to be antagonists
```
