### PR TITLE
Removes GAS, Adherent, Diona from antag.

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -4,6 +4,7 @@
 	var/list/restricted_jobs = 		list()   // Jobs that cannot be this antagonist at roundstart (depending on config)
 	var/list/protected_jobs = 		list()   // As above.
 	var/list/blacklisted_jobs =		list(/datum/job/submap)   // Jobs that can NEVER be this antagonist
+	var/list/blacklisted_species =   list(SPECIES_ADHERENT, SPECIES_DIONA, SPECIES_NABBER)
 
 	// Strings.
 	var/welcome_text = "Cry havoc and let slip the dogs of war!"

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -6,7 +6,7 @@
 		if(player.current.faction != MOB_FACTION_NEUTRAL)
 			return 0
 
-	if(is_type_in_list(player.assigned_job, blacklisted_jobs))
+	if(is_type_in_list(player.assigned_job, blacklisted_jobs) || is_type_in_list(player.current.get_species(), blacklisted_species))
 		return 0
 
 	if(!ignore_role)

--- a/html/changelogs/torque4607-PR-142.yml
+++ b/html/changelogs/torque4607-PR-142.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Torque4607
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: removed gas, diona, adherents from being able to be antagonists


### PR DESCRIPTION
## About The Pull Request

This is just a short fix that removes the three species that shouldn't be antags, from being able to _be_ antags TAKE TWO ELECTRIC BOOGAL-

## Why It's Good For The Game

Firstly, these species are balance _nightmares_ and generate a metric ton of salt afterwards. Secondly, it's also a lore thing that these wouldn't be antagonists.

## Changelog
```changelog
tweak: removed gas, diona, adherents from being able to be antagonists
```
