### PR TITLE
Removes the Psi-Advisor's Briefcase Revolver

### DIFF
--- a/html/changelogs/purplepineapple-PR-147.yml
+++ b/html/changelogs/purplepineapple-PR-147.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: PurplePineapple
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removes the Psi-Advisor's briefcase revolver."

--- a/modular_boh/code/items/psyker/agent_items.dm
+++ b/modular_boh/code/items/psyker/agent_items.dm
@@ -13,10 +13,16 @@ This file will primarily contain material relating to either Foundation Agents o
 	name = "\improper Nanotrasen briefcase"
 	desc = "A handsome black leather briefcase. 'NTPC' appears to be stamped on the handle in an obnoxious blue."
 
-/obj/item/weapon/storage/briefcase/foundation/nt/revolver	
+/obj/item/weapon/storage/briefcase/foundation/nt/revolver
 	startswith = list(
 	/obj/item/weapon/gun/projectile/revolver/foundation/agent,
 	/obj/item/ammo_magazine/speedloader/magnum/nullglass=3)
+
+/obj/item/weapon/storage/briefcase/foundation_inert
+	name = "\improper Foundation briefcase"
+	desc = "A handsome black leather briefcase embossed with a stylized radio telescope."
+	icon_state = "fbriefcase"
+	item_state = "fbriefcase"
 
 //////////
 // Unbranded Psyker Gun
@@ -39,7 +45,7 @@ This file will primarily contain material relating to either Foundation Agents o
 /////////
 /obj/item/clothing/ring/material/nullglass/New(var/newloc)
 	..(newloc, MATERIAL_NULLGLASS)
-	
+
 /////////
 // Equipment Kit
 /////////

--- a/modular_boh/code/modules/jobs/outfits/vesta_outfits.dm
+++ b/modular_boh/code/modules/jobs/outfits/vesta_outfits.dm
@@ -286,7 +286,7 @@
 	shoes = /obj/item/clothing/shoes/dress
 	pda_type = /obj/item/modular_computer/pda/heads
 	id_types = list(/obj/item/weapon/card/id/torch/crew/psiadvisor)
-	l_hand =   /obj/item/weapon/storage/briefcase/foundation
+	l_hand =   /obj/item/weapon/storage/briefcase/foundation_inert
 	holster =  /obj/item/clothing/accessory/storage/holster/waist
 
 /decl/hierarchy/outfit/job/torch/crew/command/psiadvisor/nt


### PR DESCRIPTION
They already have one in their locker, they don't need a second.