### PR TITLE
Adds CO Ammo back to the autolathe

### DIFF
--- a/html/changelogs/yawet330-3.yml
+++ b/html/changelogs/yawet330-3.yml
@@ -1,0 +1,6 @@
+author: Yawet330
+
+delete-after: True
+
+changes: 
+  - rscadd: "Adds the 454 back to the autolathe (AMMO)"

--- a/modular_boh/code/modules/designs/designs_arms_ammo.dm
+++ b/modular_boh/code/modules/designs/designs_arms_ammo.dm
@@ -6,6 +6,10 @@
 	name = "rifle magazine (5mmR), (frangible)"
 	path = /obj/item/ammo_magazine/mil_rifle/sec
 
+/datum/fabricator_recipe/arms_ammo/hidden/speedloader_large
+	name = "speedloader (.454)"
+	path = /obj/item/ammo_magazine/speedloader/large
+
 /datum/fabricator_recipe/arms_ammo/hidden/bullpupbad_extended
 	name = "rifle magazine (5mmR), (extended), (frangible)"
 	path = /obj/item/ammo_magazine/mil_rifle/sec/large


### PR DESCRIPTION
Title. This was missed in the full vesta.bay port.