### PR TITLE
KILL BAY(Or how I reverted the most griping change)

### DIFF
--- a/code/modules/fabrication/designs/general/designs_devices_components.dm
+++ b/code/modules/fabrication/designs/general/designs_devices_components.dm
@@ -52,7 +52,7 @@
 	path = /obj/item/device/assembly/prox_sensor
 
 /datum/fabricator_recipe/device_component/cable_coil
-	path = /obj/item/stack/cable_coil/single
+	path = /obj/item/stack/cable_coil
 
 /datum/fabricator_recipe/device_component/electropack
 	path = /obj/item/device/radio/electropack

--- a/html/changelogs/yawet330-4.yml
+++ b/html/changelogs/yawet330-4.yml
@@ -1,0 +1,6 @@
+author: Yawet330
+
+delete-after: True
+
+changes: 
+  - tweak: "Makes cable coils print in stacks of 30 again"


### PR DESCRIPTION
Bay didnt add a changelog for this so I dont know who to genuinely assassinate IRL. Makes cable coils print in stacks now. Fuck bay (x24)