### PR TITLE
Expands Salvage Gantry Species

### DIFF
--- a/html/changelogs/BladeburstNINJA-PR-158.yml
+++ b/html/changelogs/BladeburstNINJA-PR-158.yml
@@ -1,0 +1,6 @@
+author: BladeburstNINJA
+
+delete-after: true
+
+changes:
+  - maptweak: "Adds Skrell, Unathi, Yeosa, Shells, Tajaran, and Genemodders to Salvage Gantry."

--- a/maps/away/scavver/scavver_gantry_jobs.dm
+++ b/maps/away/scavver/scavver_gantry_jobs.dm
@@ -5,7 +5,7 @@
 	supervisors = "The trust of your fellow crew."
 	info = "You are the pilot of your meagre Scavenger Crew. Keep your crew safe, and seek supplies for your rig. \
 	Your weapons are limited; trade, salvage, but avoid conflict as a matter of course."
-	whitelisted_species = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SPACER,SPECIES_GRAVWORLDER,SPECIES_VATGROWN,SPECIES_BOOSTER,SPECIES_TRITONIAN,SPECIES_MULE)
+	whitelisted_species = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SPACER,SPECIES_GRAVWORLDER,SPECIES_VATGROWN,SPECIES_BOOSTER,SPECIES_TRITONIAN,SPECIES_MULE,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_YEOSA,SPECIES_SHELL,SPECIES_CUSTOM,SPECIES_TAJ)
 	is_semi_antagonist = TRUE
 	min_skill = list(
 		SKILL_HAULING = SKILL_BASIC,
@@ -47,7 +47,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/scavver/doctor
 	supervisors = "The trust of those you heal."
 	info = "You are the doctor aboard your meagre Salvage team. Keep everyone alive. Your weapons are limited; trade, salvage, but avoid conflict as a matter of course."
-	whitelisted_species = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SPACER,SPECIES_GRAVWORLDER,SPECIES_VATGROWN,SPECIES_BOOSTER,SPECIES_TRITONIAN,SPECIES_MULE)
+	whitelisted_species = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SPACER,SPECIES_GRAVWORLDER,SPECIES_VATGROWN,SPECIES_BOOSTER,SPECIES_TRITONIAN,SPECIES_MULE,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_YEOSA,SPECIES_SHELL,SPECIES_CUSTOM,SPECIES_TAJ)
 	is_semi_antagonist = TRUE
 	min_skill = list(
 		SKILL_HAULING = SKILL_BASIC,
@@ -90,7 +90,7 @@
 	supervisors = "The trust of your fellow crew."
 	info = "You are an Engineer aboard your meagre Salvage team. Keep your rig in functional order, upgrade what systems you can, and don't space yourself. \
 	Your weapons are limited; trade, salvage, but avoid conflict as a matter of course."
-	whitelisted_species = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SPACER,SPECIES_GRAVWORLDER,SPECIES_VATGROWN,SPECIES_BOOSTER,SPECIES_TRITONIAN,SPECIES_MULE)
+	whitelisted_species = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SPACER,SPECIES_GRAVWORLDER,SPECIES_VATGROWN,SPECIES_BOOSTER,SPECIES_TRITONIAN,SPECIES_MULE,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_YEOSA,SPECIES_SHELL,SPECIES_CUSTOM,SPECIES_TAJ)
 	is_semi_antagonist = TRUE
 	min_skill = list(
 		SKILL_HAULING = SKILL_BASIC,


### PR DESCRIPTION
Adds Skrell, Unathi, Yeosa, Shells, Tajarans, and Genemodders to the Salvage Gantry.
:cl:
maptweak: Expands the Salvage Gantry Species to include Skrell, Unathi, Yeosa, Shells, Tajarans, and Genemodders.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->