### PR TITLE
Remove restrictions from general overwear

### DIFF
--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -47,6 +47,7 @@
 	allowed_roles = FORMAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
 
+/*
 /datum/gear/suit/hoodie
 	allowed_roles = CASUAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
@@ -54,6 +55,7 @@
 /datum/gear/suit/hoodie_sel
 	allowed_roles = CASUAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
+*/
 
 /datum/gear/suit/labcoat
 	allowed_roles = DOCTOR_ROLES
@@ -76,6 +78,7 @@
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/rd/ec
 	allowed_roles = list(/datum/job/rd)
 
+/*
 /datum/gear/suit/wintercoat_dais
 	display_name = "winter coat, DAIS"
 	allowed_roles = list(/datum/job/engineer, /datum/job/roboticist, /datum/job/scientist_assistant, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/rd)
@@ -89,6 +92,7 @@
 
 /datum/gear/suit/wintercoat
 	allowed_branches = CIVILIAN_BRANCHES
+*/
 
 /datum/gear/suit/track
 	allowed_roles = CASUAL_ROLES

--- a/modular_boh/loadouts/custom_loadouts.dm
+++ b/modular_boh/loadouts/custom_loadouts.dm
@@ -510,3 +510,17 @@ datum/gear/head/ECdepartment/New()
 /datum/gear/augmentation/implanted_circuitkit/right
 	display_name = "circuit augment - right arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/simple/circuit/right
+
+// Jackets and coats
+/datum/gear/suit/wintercoat_dais
+	display_name = "winter coat, DAIS"
+
+/datum/gear/suit/coat
+
+/datum/gear/suit/leather
+
+/datum/gear/suit/wintercoat
+
+/datum/gear/suit/hoodie
+
+/datum/gear/suit/hoodie_sel


### PR DESCRIPTION
All this changes is removing the civilian-only tags to the normal jackets and hoodies.