### PR TITLE
Makes foundation briefcase psi-shielded again

### DIFF
--- a/html/changelogs/eonoc-PR-162.yml
+++ b/html/changelogs/eonoc-PR-162.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Eonoc
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Made the Foundation briefcase psi-shielded again. Hurrah."

--- a/modular_boh/code/items/psyker/agent_items.dm
+++ b/modular_boh/code/items/psyker/agent_items.dm
@@ -24,6 +24,11 @@ This file will primarily contain material relating to either Foundation Agents o
 	icon_state = "fbriefcase"
 	item_state = "fbriefcase"
 
+/obj/item/weapon/storage/briefcase/foundation_inert/disrupts_psionics()
+	return FALSE
+
+
+
 //////////
 // Unbranded Psyker Gun
 //////////


### PR DESCRIPTION
Adds two lines that should make psi-dampening items in the briefcase not dampen the holders powers, as on original Vesta.
I cry because I have to make an actual changelog document, and can't just put it in here.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->