### PR TITLE
Adds paygrades to ranks for characters setup and crew records

### DIFF
--- a/html/changelogs/hekzder-PR-170.yml
+++ b/html/changelogs/hekzder-PR-170.yml
@@ -1,0 +1,4 @@
+author: Hekzder
+delete-after: True
+changes: 
+  - rscadd: "Paygrades have been added to all ranks to view in character setup and crew records."

--- a/modular_boh/code/game/ranks/vesta_ranks.dm
+++ b/modular_boh/code/game/ranks/vesta_ranks.dm
@@ -293,198 +293,198 @@
  *  =====
  */
 /datum/mil_rank/fleet/e1
-	name = "Crewman Recruit"
+	name = "Crewman Recruit (E-1)"
 	name_short = "CR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 1
 
 
 /datum/mil_rank/fleet/e2
-	name = "Crewman Apprentice"
+	name = "Crewman Apprentice (E-2)"
 	name_short = "CA"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 2
 
 
 /datum/mil_rank/fleet/e3
-	name = "Crewman"
+	name = "Crewman (E-3)"
 	name_short = "CN"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 3
 
 
 /datum/mil_rank/fleet/e4
-	name = "Petty Officer Third Class"
+	name = "Petty Officer Third Class (E-4)"
 	name_short = "PO3"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 4
 
 
 /datum/mil_rank/fleet/e5
-	name = "Petty Officer Second Class"
+	name = "Petty Officer Second Class (E-5)"
 	name_short = "PO2"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e5, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 5
 
 
 /datum/mil_rank/fleet/e6
-	name = "Petty Officer First Class"
+	name = "Petty Officer First Class (E-6)"
 	name_short = "PO1"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e6, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 6
 
 
 /datum/mil_rank/fleet/e7
-	name = "Chief Petty Officer"
+	name = "Chief Petty Officer (E-7)"
 	name_short = "CPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 7
 
 
 /datum/mil_rank/fleet/e8
-	name = "Senior Chief Petty Officer"
+	name = "Senior Chief Petty Officer (E-8)"
 	name_short = "SCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e8, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 8
 
 
 /datum/mil_rank/fleet/e9
-	name = "Master Chief Petty Officer"
+	name = "Master Chief Petty Officer (E-9)"
 	name_short = "MCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 
 
 /datum/mil_rank/fleet/e9_alt1
-	name = "Command Master Chief Petty Officer"
+	name = "Command Master Chief Petty Officer (E-9)"
 	name_short = "CMCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt1, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 
 
 /datum/mil_rank/fleet/e9_alt2
-	name = "Fleet Master Chief Petty Officer"
+	name = "Fleet Master Chief Petty Officer (E-9)"
 	name_short = "FLTCM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 
 
 /datum/mil_rank/fleet/e9_alt3
-	name = "Force Master Chief Petty Officer"
+	name = "Force Master Chief Petty Officer (E-9)"
 	name_short = "FORCM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 
 
 /datum/mil_rank/fleet/e9_alt4
-	name = "Master Chief Petty Officer of the Fleet"
+	name = "Master Chief Petty Officer of the Fleet (E-9)"
 	name_short = "MCPOF"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 
 
 /datum/mil_rank/fleet/w1
-	name = "Junior Warrant Officer"
+	name = "Junior Warrant Officer (W-1)"
 	name_short = "JWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w1)
 	sort_order = 11
 
 /datum/mil_rank/fleet/w2
-	name = "Chief Warrant Officer"
+	name = "Chief Warrant Officer (W-2)"
 	name_short = "CWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w2)
 	sort_order = 12
 
 /datum/mil_rank/fleet/w3
-	name = "Senior Chief Warrant Officer"
+	name = "Senior Chief Warrant Officer (W-3)"
 	name_short = "SCWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w3)
 	sort_order = 13
 
 /datum/mil_rank/fleet/w4
-	name = "Master Chief Warrant Officer"
+	name = "Master Chief Warrant Officer (W-4)"
 	name_short = "MCWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w4)
 	sort_order = 14
 
 /datum/mil_rank/fleet/w5
-	name = "Command Master Chief Warrant Officer"
+	name = "Command Master Chief Warrant Officer (W-5)"
 	name_short = "CMCWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w5)
 	sort_order = 15
 
 /datum/mil_rank/fleet/o1
-	name = "Ensign"
+	name = "Ensign (O-1)"
 	name_short = "ENS"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 16
 
 
 /datum/mil_rank/fleet/o2
-	name = "Lieutenant Junior-Grade"
+	name = "Lieutenant Junior-Grade (O-2)"
 	name_short = "LTJG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o2, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 17
 
 
 /datum/mil_rank/fleet/o3
-	name = "Lieutenant"
+	name = "Lieutenant (O-3)"
 	name_short = "LT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o3, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 18
 
 
 /datum/mil_rank/fleet/o4
-	name = "Lieutenant Commander"
+	name = "Lieutenant Commander (O-4)"
 	name_short = "LCDR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o4, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 19
 
 
 /datum/mil_rank/fleet/o5
-	name = "Commander"
+	name = "Commander (O-5)"
 	name_short = "CDR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o5, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 20
 
 
 /datum/mil_rank/fleet/o6
-	name = "Captain"
+	name = "Captain (O-6)"
 	name_short = "CAPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o6, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 21
 
 
 /datum/mil_rank/fleet/o7
-	name = "Commodore"
+	name = "Commodore (O-7)"
 	name_short = "CDRE"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 22
 
 
 /datum/mil_rank/fleet/o8
-	name = "Rear Admiral"
+	name = "Rear Admiral (O-8)"
 	name_short = "RADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o8, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 23
 
 
 /datum/mil_rank/fleet/o9
-	name = "Vice Admiral"
+	name = "Vice Admiral (O-9)"
 	name_short = "VADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o9, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 24
 
 
 /datum/mil_rank/fleet/o10
-	name = "Admiral"
+	name = "Admiral (O-10)"
 	name_short = "ADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 25
 
 
 /datum/mil_rank/fleet/o10_alt
-	name = "Fleet Admiral"
+	name = "Fleet Admiral (O-10)"
 	name_short = "FADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10_alt, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 25
@@ -496,135 +496,135 @@
  *  ============
  */
 /datum/mil_rank/marine_corps/e1
-	name = "Private"
+	name = "Private (E-1)"
 	name_short = "Pvt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted)
 	sort_order = 1
 
 
 /datum/mil_rank/marine_corps/e2
-	name = "Private First Class"
+	name = "Private First Class (E-2)"
 	name_short = "PFC"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e2)
 	sort_order = 2
 
 
 /datum/mil_rank/marine_corps/e3
-	name = "Lance Corporal"
+	name = "Lance Corporal (E-3)"
 	name_short = "LCpl"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e3)
 	sort_order = 3
 
 
 /datum/mil_rank/marine_corps/e4
-	name = "Corporal"
+	name = "Corporal (E-4)"
 	name_short = "Cpl"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e4)
 	sort_order = 4
 
 
 /datum/mil_rank/marine_corps/e5
-	name = "Sergeant"
+	name = "Sergeant (E-5)"
 	name_short = "Sgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e5)
 	sort_order = 5
 
 
 /datum/mil_rank/marine_corps/e6
-	name = "Staff Sergeant"
+	name = "Staff Sergeant (E-6)"
 	name_short = "SSgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e6)
 	sort_order = 6
 
 
 /datum/mil_rank/marine_corps/e7
-	name = "Gunnery Sergeant"
+	name = "Gunnery Sergeant (E-7)"
 	name_short = "GySgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e7)
 	sort_order = 7
 
 
 /datum/mil_rank/marine_corps/e8
-	name = "Master Sergeant"
+	name = "Master Sergeant (E-8)"
 	name_short = "MSgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e8)
 	sort_order = 8
 
 
 /datum/mil_rank/marine_corps/e8_alt
-	name = "First Sergeant"
+	name = "First Sergeant (E-8)"
 	name_short = "1SG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e8_alt)
 	sort_order = 8
 
 
 /datum/mil_rank/marine_corps/e9
-	name = "Master Gunnery Sergeant"
+	name = "Master Gunnery Sergeant (E-9)"
 	name_short = "MGySgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9)
 	sort_order = 9
 
 
 /datum/mil_rank/marine_corps/e9_alt
-	name = "Sergeant Major"
+	name = "Sergeant Major (E-9)"
 	name_short = "SgtMaj"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9_alt)
 	sort_order = 9
 
 
 /datum/mil_rank/marine_corps/e9_alt2
-	name = "Sergeant Major of the Marine Corps"
+	name = "Sergeant Major of the Marine Corps (E-9)"
 	name_short = "SMMC"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9_alt2)
 	sort_order = 9
 
 
 /datum/mil_rank/marine_corps/w1
-	name = "Warrant Officer"
+	name = "Warrant Officer (W-1)"
 	name_short = "WO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w1)
 	sort_order = 11
 
 /datum/mil_rank/marine_corps/w2
-	name = "Second Warrant Officer"
+	name = "Second Warrant Officer (W-2)"
 	name_short = "SWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w2)
 	sort_order = 12
 
 /datum/mil_rank/marine_corps/w3
-	name = "First Warrant Officer"
+	name = "First Warrant Officer (W-3)"
 	name_short = "FWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w3)
 	sort_order = 13
 
 /datum/mil_rank/marine_corps/w4
-	name = "Major Warrant Officer"
+	name = "Major Warrant Officer (W-4)"
 	name_short = "MWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w4)
 	sort_order = 14
 
 /datum/mil_rank/marine_corps/w5
-	name = "General Warrant Officer"
+	name = "General Warrant Officer (W-5)"
 	name_short = "GWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w5)
 	sort_order = 15
 
 /datum/mil_rank/marine_corps/o1
-	name = "Second Lieutenant"
+	name = "Second Lieutenant (O-1)"
 	name_short = "2ndLt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer)
 	sort_order = 16
 
 
 /datum/mil_rank/marine_corps/o2
-	name = "First Lieutenant"
+	name = "First Lieutenant (O-2)"
 	name_short = "1stLt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o2)
 	sort_order = 17
 
 
 /datum/mil_rank/marine_corps/o3
-	name = "Captain "
+	name = "Captain (O-3)"
 	name_short = "CPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o3)
 	sort_order = 18
@@ -646,49 +646,49 @@
 
 
 /datum/mil_rank/marine_corps/o4
-	name = "Major"
+	name = "Major (O-4)"
 	name_short = "Maj"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o4)
 	sort_order = 21
 
 
 /datum/mil_rank/marine_corps/o5
-	name = "Lieutenant Colonel"
+	name = "Lieutenant Colonel (O-5)"
 	name_short = "LtCol"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o5)
 	sort_order = 22
 
 
 /datum/mil_rank/marine_corps/o6
-	name = "Colonel"
+	name = "Colonel (O-6)"
 	name_short = "Col"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o6)
 	sort_order = 23
 
 
 /datum/mil_rank/marine_corps/o7
-	name = "Brigadier General"
+	name = "Brigadier General (O-7)"
 	name_short = "BGen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag)
 	sort_order = 24
 
 
 /datum/mil_rank/marine_corps/o8
-	name = "Major General"
+	name = "Major General (O-8)"
 	name_short = "MGen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o8)
 	sort_order = 25
 
 
 /datum/mil_rank/marine_corps/o9
-	name = "Lieutenant General"
+	name = "Lieutenant General (O-9)"
 	name_short = "LtGen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o9)
 	sort_order = 26
 
 
 /datum/mil_rank/marine_corps/o10
-	name = "General"
+	name = "General (O-10)"
 	name_short = "Gen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o10)
 	sort_order = 27


### PR DESCRIPTION
Literally just the title. QoL change with effectively zero down sides, just helps newer or less mil-sim inclined players to better understand the ranking structure. This change should only be seen in character setup and when viewing character records. Probably the most effective for SEA which has multiple ranks of the same pay grade and can get confusing.