### PR TITLE
adds binos and GPS to colony + ascent seedship also getting them

### DIFF
--- a/html/changelogs/gilvian-PR-183.yml
+++ b/html/changelogs/gilvian-PR-183.yml
@@ -1,0 +1,6 @@
+author: Gilvian
+
+delete-after: True
+
+changes: 
+  - tweak: "Adds Binos and GPS to colony."

--- a/html/changelogs/gilvian-PR-183.yml
+++ b/html/changelogs/gilvian-PR-183.yml
@@ -3,4 +3,4 @@ author: Gilvian
 delete-after: True
 
 changes: 
-  - tweak: "Adds Binos and GPS to colony."
+  - tweak: "Adds Binos and GPS to colony and ascent seedship."

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -4332,6 +4332,18 @@
 /obj/machinery/recharge_station/ascent,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
+"mJ" = (
+/obj/structure/table/rack/dark,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/fore_starboard_prow)
 "mM" = (
 /obj/machinery/light/ascent,
 /obj/effect/catwalk_plated/ascent,
@@ -12159,7 +12171,7 @@ ah
 as
 as
 as
-as
+mJ
 bz
 lG
 br

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -8245,42 +8245,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
-"oi" = (
-/obj/structure/railing/mapped,
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/table/rack,
-/obj/item/stack/material/rods/fifty,
-/obj/item/stack/material/rods/fifty,
-/obj/item/stack/material/rods/fifty,
-/obj/item/stack/material/rods/fifty,
-/obj/item/weapon/pickaxe,
-/obj/item/weapon/pickaxe,
-/obj/item/weapon/shovel,
-/obj/item/weapon/shovel,
-/obj/item/weapon/storage/ore,
-/obj/item/weapon/storage/ore,
-/obj/item/weapon/storage/backpack/dufflebag/eng,
-/obj/item/weapon/storage/backpack/dufflebag/eng,
-/obj/machinery/door/window/northright,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/weapon/cell/super,
-/obj/item/weapon/cell/super,
-/obj/item/weapon/cell/super,
-/obj/item/device/scanner/mining,
-/obj/item/weapon/storage/box/greenglowsticks,
-/obj/item/weapon/storage/box/greenglowsticks,
-/obj/item/weapon/storage/box/greenglowsticks,
-/obj/item/stack/flag/yellow,
-/obj/item/stack/flag/yellow,
-/obj/item/stack/flag/yellow,
-/turf/simulated/floor/exoplanet/concrete,
-/area/map_template/colony/mineralprocessing)
 "oj" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -8756,6 +8720,47 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/hydroponics)
+"Bw" = (
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/structure/table/rack,
+/obj/item/stack/material/rods/fifty,
+/obj/item/stack/material/rods/fifty,
+/obj/item/stack/material/rods/fifty,
+/obj/item/stack/material/rods/fifty,
+/obj/item/weapon/pickaxe,
+/obj/item/weapon/pickaxe,
+/obj/item/weapon/shovel,
+/obj/item/weapon/shovel,
+/obj/item/weapon/storage/ore,
+/obj/item/weapon/storage/ore,
+/obj/item/weapon/storage/backpack/dufflebag/eng,
+/obj/item/weapon/storage/backpack/dufflebag/eng,
+/obj/machinery/door/window/northright,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/weapon/cell/super,
+/obj/item/weapon/cell/super,
+/obj/item/weapon/cell/super,
+/obj/item/device/scanner/mining,
+/obj/item/weapon/storage/box/greenglowsticks,
+/obj/item/weapon/storage/box/greenglowsticks,
+/obj/item/weapon/storage/box/greenglowsticks,
+/obj/item/stack/flag/yellow,
+/obj/item/stack/flag/yellow,
+/obj/item/stack/flag/yellow,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/turf/simulated/floor/exoplanet/concrete,
+/area/map_template/colony/mineralprocessing)
 "Dj" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
@@ -9632,7 +9637,7 @@ lv
 lD
 lV
 la
-oi
+Bw
 nA
 fc
 "}


### PR DESCRIPTION
Adds a pair of binos and GPS to colony.

Why? To have them not get lost.

EDIT: I was asked to add them also to Ascent, they get a new rack next to their mining gear with those items.