### PR TITLE
Adds O-2 back to Chaplain

### DIFF
--- a/html/changelogs/hekzder-PR-188.yml
+++ b/html/changelogs/hekzder-PR-188.yml
@@ -1,0 +1,4 @@
+author: Hekzder
+delete-after: True
+changes: 
+  - rscadd: "Chaplain gets O-2 again since BO gets it as well."

--- a/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
+++ b/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
@@ -360,7 +360,9 @@
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/fleet/o1,
-		/datum/mil_rank/marine_corps/o1
+		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/marine_corps/o1,
+		/datum/mil_rank/marine_corps/o2
 	)
 
 /datum/job/janitor


### PR DESCRIPTION
Pretty much just the title. I originally removed O-2 from Chaplain since BO was getting it removed, BO now gets it back so Chaplain should as well. This should appease the one uniformed Chaplain player among us. But in all seriousness this is mostly just for consistency sake, I don't really think anyone cares about this too much. 