### PR TITLE
Vox Merchant: Himbo Edition

### DIFF
--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -6,7 +6,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR, 
 		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_PISTOL,
+		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_MINOR, 
 		bomb = ARMOR_BOMB_PADDED, 
 		bio = ARMOR_BIO_SMALL, 
@@ -26,7 +26,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR, 
 		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_PISTOL,
+		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_MINOR, 
 		bomb = ARMOR_BOMB_PADDED, 
 		bio = ARMOR_BIO_SMALL, 

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -6,7 +6,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR, 
 		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_HANDGUNS,
+		laser = ARMOR_LASER_PISTOL,
 		energy = ARMOR_ENERGY_MINOR, 
 		bomb = ARMOR_BOMB_PADDED, 
 		bio = ARMOR_BIO_SMALL, 
@@ -26,7 +26,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR, 
 		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_HANDGUNS,
+		laser = ARMOR_LASER_PISTOL,
 		energy = ARMOR_ENERGY_MINOR, 
 		bomb = ARMOR_BOMB_PADDED, 
 		bio = ARMOR_BIO_SMALL, 

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -6,7 +6,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR, 
 		bullet = ARMOR_BALLISTIC_RESISTANT, 
-		laser = ARMOR_LASER_PISTOL, 
+		laser = ARMOR_LASER_HANDGUNS, 
 		energy = ARMOR_ENERGY_RESISTANT, 
 		bomb = ARMOR_BOMB_PADDED, 
 		bio = ARMOR_BIO_SHIELDED, 

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -6,7 +6,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR, 
 		bullet = ARMOR_BALLISTIC_RESISTANT, 
-		laser = ARMOR_LASER_HANDGUNS, 
+		laser = ARMOR_LASER_PISTOL, 
 		energy = ARMOR_ENERGY_RESISTANT, 
 		bomb = ARMOR_BOMB_PADDED, 
 		bio = ARMOR_BIO_SHIELDED, 

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -52,7 +52,7 @@
 	siemens_coefficient = 0.2
 
 	species_flags = SPECIES_FLAG_NO_SCAN
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_NO_FBP_CONSTRUCTION
+	spawn_flags = SPECIES_CAN_JOIN // | SPECIES_IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 	blood_color = "#2299fc"
@@ -153,9 +153,10 @@
 
 	slowdown = 1
 	hidden_from_codex = TRUE
-	spawn_flags = SPECIES_IS_WHITELISTED | SPECIES_NO_FBP_CONSTRUCTION
-	brute_mod = 0.8
-	burn_mod = 0.8
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_IS_WHITELISTED
+	brute_mod = 0.6
+	burn_mod = 0.6
+	toxins_mod = 1.2
 	strength = STR_HIGH
 
 	override_organ_types = list(BP_EYES = /obj/item/organ/internal/eyes/vox/armalis)

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -161,8 +161,6 @@
 	mob_size = MOB_LARGE
 	
 	bump_flag = HEAVY
-	push_flag = ALLMOBS
-	swap_flag = ALLMOBS
 	
 	species_flags = SPECIES_FLAG_NO_MINOR_CUT
 	

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -151,13 +151,23 @@
 	damage_mask =     'icons/mob/human_races/species/vox/damage_mask_armalis.dmi'
 	blood_mask =      'icons/mob/human_races/species/vox/blood_mask_armalis.dmi'
 
-	slowdown = 1
-	hidden_from_codex = TRUE
+	slowdown = 1.5
+	hidden_from_codex = FALSE
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_IS_WHITELISTED
 	brute_mod = 0.6
 	burn_mod = 0.6
 	toxins_mod = 1.2
 	strength = STR_HIGH
+	mob_size = MOB_LARGE
+	
+	bump_flag = HEAVY
+	push_flag = ALLMOBS
+	swap_flag = ALLMOBS
+	
+	species_flags = SPECIES_FLAG_NO_MINOR_CUT
+	
+	speech_sounds = list('sound/voice/shriek1.ogg')
+	speech_chance = 25
 
 	override_organ_types = list(BP_EYES = /obj/item/organ/internal/eyes/vox/armalis)
 
@@ -175,3 +185,11 @@
 		slot_back_str =   list("[NORTH]" = list("x" = 0, "y" = 8), "[EAST]" = list("x" = -3, "y" = 8), "[SOUTH]" = list("x" = 0, "y" = 8), "[WEST]" = list("x" =  3, "y" = 8)),
 		slot_belt_str =   list("[NORTH]" = list("x" = 0, "y" = 8), "[EAST]" = list("x" = -4, "y" = 8), "[SOUTH]" = list("x" = 0, "y" = 8), "[WEST]" = list("x" =  4, "y" = 8))
 	)
+	
+/datum/species/vox/armalis/attempt_grab(var/mob/living/carbon/human/grabber, var/mob/living/target)
+	if(grabber != target)
+		grabber.unEquip(grabber.l_hand)
+		grabber.unEquip(grabber.r_hand)
+		to_chat(grabber, SPAN_WARNING("You drop everything in a rage as you seize \the [target]!"))
+		playsound(grabber.loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
+	. = ..(grabber, target, GRAB_NAB)

--- a/html/changelogs/superhats-PR-191.yml
+++ b/html/changelogs/superhats-PR-191.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Superhats
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "After a botched lawsuit from the FTU, Vox are not once again allowed to work as merchants."
+  - tweak: "Someone spilled juice on the armalis dispenser, but we fixed it. Armalis are once again playable, for whitelisted players only."
+  - tweak: "Consequently, armalis stats have been brought down to their pre-rebayse values."

--- a/html/changelogs/superhats-PR-191.yml
+++ b/html/changelogs/superhats-PR-191.yml
@@ -34,6 +34,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "After a botched lawsuit from the FTU, Vox are not once again allowed to work as merchants."
+  - tweak: "After a botched lawsuit from the FTU, Vox are now once again allowed to work as merchants."
   - tweak: "Someone spilled juice on the armalis dispenser, but we fixed it. Armalis are once again playable, for whitelisted players only."
   - tweak: "Consequently, armalis stats have been brought down to their pre-rebayse values."

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -5,7 +5,8 @@
 										/datum/job/mining),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
-		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg),
+		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
+		/datum/species/vox/armalis = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 


### PR DESCRIPTION
This PR both removes the whitelist for standard vox, gives them the ability to use FBPs again, and brings back Vox merchants, after eonoc, the current bay vox person, said they were in fact lore friendly.
![image](https://user-images.githubusercontent.com/21011148/103397701-c37e8580-4b39-11eb-84b2-f1ba2a99a4bf.png)
This also tweaks Vox Armalis back to hestia values.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->