### PR TITLE
Adjusts Marine WO ranks

### DIFF
--- a/html/changelogs/hekzder-PR-198.yml
+++ b/html/changelogs/hekzder-PR-198.yml
@@ -1,0 +1,4 @@
+author: Hekzder
+delete-after: True
+changes: 
+  - tweak: "Removes Warrant Officer as Marine W-1. Shifts Second and First Warrant officer down to compensate. Master Warrant Officer added at W-3."

--- a/modular_boh/code/game/ranks/vesta_ranks.dm
+++ b/modular_boh/code/game/ranks/vesta_ranks.dm
@@ -604,7 +604,7 @@
 	sort_order = 14
 
 /datum/mil_rank/marine_corps/w5
-	name = "Major Warrant Officer of the Marine Corps (W-5)"
+	name = "General Warrant Officer (W-5)"
 	name_short = "MWOMC"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w5)
 	sort_order = 15

--- a/modular_boh/code/game/ranks/vesta_ranks.dm
+++ b/modular_boh/code/game/ranks/vesta_ranks.dm
@@ -580,32 +580,32 @@
 
 
 /datum/mil_rank/marine_corps/w1
-	name = "Warrant Officer (W-1)"
-	name_short = "WO"
+	name = "Second Warrant Officer (W-1)"
+	name_short = "2ndWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w1)
 	sort_order = 11
 
 /datum/mil_rank/marine_corps/w2
-	name = "Second Warrant Officer (W-2)"
-	name_short = "SWO"
+	name = "First Warrant Officer (W-2)"
+	name_short = "1stWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w2)
 	sort_order = 12
 
 /datum/mil_rank/marine_corps/w3
-	name = "First Warrant Officer (W-3)"
-	name_short = "FWO"
+	name = "Master Warrant Officer (W-3)"
+	name_short = "MWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w3)
 	sort_order = 13
 
 /datum/mil_rank/marine_corps/w4
 	name = "Major Warrant Officer (W-4)"
-	name_short = "MWO"
+	name_short = "MajWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w4)
 	sort_order = 14
 
 /datum/mil_rank/marine_corps/w5
-	name = "General Warrant Officer (W-5)"
-	name_short = "GWO"
+	name = "Major Warrant Officer of the Marine Corps (W-5)"
+	name_short = "MWOMC"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w5)
 	sort_order = 15
 

--- a/modular_boh/code/game/ranks/vesta_ranks.dm
+++ b/modular_boh/code/game/ranks/vesta_ranks.dm
@@ -605,7 +605,7 @@
 
 /datum/mil_rank/marine_corps/w5
 	name = "General Warrant Officer (W-5)"
-	name_short = "MWOMC"
+	name_short = "GWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w5)
 	sort_order = 15
 

--- a/modular_boh/code/items/clothing/boh_accessory.dm
+++ b/modular_boh/code/items/clothing/boh_accessory.dm
@@ -275,8 +275,8 @@
 /obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w5
 	icon_state = "MW5"
 	overlay_state = "armyrank_warrant_stripe"
-	name = "ranks (W-5 major warrant officer of the marine corps)"
-	desc = "Insignia denoting the rank of Major Warrant Officer of the Marine Corps"
+	name = "ranks (W-5 general warrant officer)"
+	desc = "Insignia denoting the rank of General Warrant Officer"
 
 /obj/item/clothing/accessory/solgov/rank/marine_corps/officer
 	icon_state = "MO1A"

--- a/modular_boh/code/items/clothing/boh_accessory.dm
+++ b/modular_boh/code/items/clothing/boh_accessory.dm
@@ -252,19 +252,19 @@
 
 /obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w1
 	icon_state = "MW1"
-	name = "ranks (W-1 warrant officer)"
-	desc = "Insignia denoting the rank of Warrant Officer"
+	name = "ranks (W-1 second warrant officer)"
+	desc = "Insignia denoting the rank of Second Warrant Officer"
 
 /obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w2
 	icon_state = "MW2"
-	name = "ranks (W-2 second warrant officer"
-	desc = "Insignia denoting the rank of Second Warrant Officer"
+	name = "ranks (W-2 first warrant officer)"
+	desc = "Insignia denoting the rank of First Warrant Officer"
 
 /obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w3
 	icon_state = "MW3"
 	overlay_state = "armyrank_warrant_silver"
-	name = "ranks (W-3 first warrant officer)"
-	desc = "Insignia denoting the rank of First Warrant Officer"
+	name = "ranks (W-3 master warrant officer)"
+	desc = "Insignia denoting the rank of Master Warrant Officer"
 
 /obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w4
 	icon_state = "MW4"
@@ -275,8 +275,8 @@
 /obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w5
 	icon_state = "MW5"
 	overlay_state = "armyrank_warrant_stripe"
-	name = "ranks (W-5 general warrant officer)"
-	desc = "Insignia denoting the rank of General Warrant Officer"
+	name = "ranks (W-5 major warrant officer of the marine corps)"
+	desc = "Insignia denoting the rank of Major Warrant Officer of the Marine Corps"
 
 /obj/item/clothing/accessory/solgov/rank/marine_corps/officer
 	icon_state = "MO1A"


### PR DESCRIPTION
Removes the weird "Warrant Officer" from W-1 for SMC WOs, shifts Second and First Warrant Officer down to compensate. W-3 is now Master Warrant Officer.

This is mostly just a fix to the incredibly weird and out of place "Warrant Officer" at the beginning of Marine WO ranks. Our current Marine WO ranks use officer ranks as the basis, "Warrant Officer" is a complete black sheep. Marine WO ranks now use officer ranks as the basis for the first couple ranks, then shift to Senior Enlisted as the basis for later ranks, on par with how we handle Fleet WO ranks. 

This doesn't change actual ranking structure at all. If you have an SMC WO character currently at W-2, Second Warrant Officer, you're more than welcome to just keep them at W-2. This isn't really a promotion or demotion for anyone, this doesn't touch actual rank options or distributions, it's just a fix for a very weird and out of place rank name. 