### PR TITLE
Grenades are now deadly.

### DIFF
--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -1,5 +1,5 @@
 /obj/item/projectile/bullet/pellet/fragment
-	damage = 7
+	damage = 30
 	range_step = 2 //controls damage falloff with distance. projectiles lose a "pellet" each time they travel this distance. Can be a non-integer.
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
@@ -11,7 +11,8 @@
 	muzzle_type = null
 
 /obj/item/projectile/bullet/pellet/fragment/strong
-	damage = 15
+	damage = 30
+	armor_penetration = 40
 
 /obj/item/weapon/grenade/frag
 	name = "fragmentation grenade"

--- a/html/changelogs/vhbraz-PR-202.yml
+++ b/html/changelogs/vhbraz-PR-202.yml
@@ -1,0 +1,4 @@
+author: Vhbraz
+delete-after: True
+changes: 
+  - tweak: "Grenade fragment damages have been re-adjusted to be more lethal."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Grenades are currently at a laughable state where getting hit by five fragmentation shells will hardly give you any damage above significant.

This PR makes fragmentation grenades much more deadly (Especially to those without an EOD or proper armor).