### PR TITLE
Increases Crashed Survival Pod Slots to 3

### DIFF
--- a/html/changelogs/hekzder-PR-212.yml
+++ b/html/changelogs/hekzder-PR-212.yml
@@ -1,0 +1,4 @@
+author: Hekzder
+delete-after: True
+changes: 
+  - tweak: "Increased Crashed Survival Pod slots to 3 from 2. Mapping to accomodate like increased spawn points and another emergency locker."

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	title = "Stranded Survivor"
 	info = "Your ship has been destroyed by a terrible disaster."
 	outfit_type = /decl/hierarchy/outfit/job/survivor
-	total_positions = 2
+	total_positions = 3
 
 /decl/hierarchy/outfit/job/survivor
 	name = OUTFIT_JOB_NAME("Survivor")

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -894,12 +894,12 @@
 /obj/structure/closet/hydrant{
 	pixel_x = -27
 	},
+/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "gD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/cleanable/filth,
-/obj/item/device/binoculars,
 /obj/machinery/alarm{
 	dir = 4;
 	locked = 0;
@@ -907,6 +907,7 @@
 	pixel_y = 0;
 	req_access = list()
 	},
+/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "gE" = (
@@ -1041,6 +1042,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/metal,
+/obj/item/device/binoculars,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "hm" = (
@@ -1054,10 +1056,6 @@
 "lG" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"pO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "vG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1253,7 +1251,7 @@ gw
 gG
 ay
 hm
-pO
+hi
 lG
 "}
 (10,1,1) = {"


### PR DESCRIPTION
Basically the title. I think two is too few but it was pointed out by some that four would be too excessive, either because it would mitigate the challenge of survival pod or just because our current survival pod is very cramped. Both valid points, three is a happy compromise. 

Mapping of increased spawn points to compensate, as well as another soft suit/emergency locker. 