### PR TITLE
Adjusts various skill points

### DIFF
--- a/html/changelogs/hekzder-PR-217.yml
+++ b/html/changelogs/hekzder-PR-217.yml
@@ -1,0 +1,7 @@
+author: Hekzder
+delete-after: True
+changes: 
+  - tweak: "Roboticist and Squad Lead now have +2 skill points."
+  - tweak: "CMO, Resident, Medical Technician, Scientist, Combat Technician, and Bridge Officer now have -2 skill points."
+  - tweak: "Physician now has -4 skill points."
+  - tweak: "Psionic Advisor now has -6 skill points."

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -175,7 +175,7 @@
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
 	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
-	skill_points = 26
+	skill_points = 24
 
 	access = list(
 		access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -410,7 +410,7 @@
 	                    SKILL_PILOT       = SKILL_ADEPT)
 
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
-	skill_points = 22
+	skill_points = 20
 
 
 	access = list(

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -33,7 +33,7 @@
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
 	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
-	skill_points = 20
+	skill_points = 16
 
 	access = list(
 		access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
@@ -78,7 +78,7 @@
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
 	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
-	skill_points = 16
+	skill_points = 14
 
 	access = list(
 		access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
@@ -134,7 +134,7 @@
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)
-	skill_points = 22
+	skill_points = 20
 
 /datum/job/medical_trainee
 	title = "Trainee Medical Technician"

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -88,7 +88,7 @@
 	)
 
 	minimal_access = list()
-	skill_points = 24
+	skill_points = 22
 
 /datum/job/scientist_assistant
 	title = "Research Assistant"

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -31,7 +31,7 @@ var/const/INF               =(1<<11)
 	selection_color = "#557e38"
 	minimal_player_age = 12
 	economic_power = 7
-	skill_points = 24
+	skill_points = 26
 	is_whitelisted = TRUE
 	minimum_character_age = list(SPECIES_HUMAN = 25)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
@@ -178,7 +178,7 @@ var/const/INF               =(1<<11)
 		SKILL_COMBAT     = SKILL_EXPERT,
 		SKILL_WEAPONS     = SKILL_EXPERT
 	)
-	skill_points = 30
+	skill_points = 24
 	access = list(access_psiadvisor, access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks,
 				access_eva, access_bridge, access_cargo, access_RC_announce, access_solgov_crew, access_hangar)
 	minimal_access = list()
@@ -347,7 +347,7 @@ var/const/INF               =(1<<11)
 	                    SKILL_DEVICES      = SKILL_MAX,
 	                    SKILL_MEDICAL      = SKILL_EXPERT,
 	                    SKILL_ANATOMY      = SKILL_EXPERT)
-	skill_points = 20
+	skill_points = 22
 
 	access = list(access_maint_tunnels, access_research, access_robotics, access_nanotrasen, access_solgov_crew, access_surgery, access_medical)
 	minimal_access = list()

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -68,7 +68,7 @@ var/const/INF               =(1<<11)
 	selection_color = "#557e38"
 	economic_power = 4
 	minimal_player_age = 8
-	skill_points = 24
+	skill_points = 22
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/infantry/combat_tech
 	minimum_character_age = list(SPECIES_HUMAN = 20)
 	min_skill = list(	SKILL_CONSTRUCTION = SKILL_ADEPT,


### PR DESCRIPTION
Basically the title. 

### **The following jobs got increased skill points:**

**Squad Lead**: +2 - Combat Technician has a _substantially_ better and more expensive starting/guaranteed skill spread than SL, _and_ gets the same amount of free skill points to spend. This change, along with the CT -2 skill points, remedies that and follows the trend of the more experienced leaders of groups/departments on the Dagon having that experience reflected in more skill points.

**Roboticist**: +2 - Roboticist Biomechs have incredibly few fluff skill points to spend after getting the skill points they're likely to get to do their job. +2 should help have a few more points to spend just on your character. 

### **The following jobs got decreased skill points:**

**Physician**: -4 - Currently as a Physician, you can Master Anat, Medicine, and Trained Chem while having 8 fluff points left over. Given that Master Anat and Master Medicine is arguably fluff as is, this is definitely indicative of Physician being slightly overtuned in terms of points. Yes, medical skills are expensive, but Physicians have the skills to do their job perfectly fine with just their starting/guaranteed skill points alone. Chem is _arguably_ not a job requirement either since you're a surgeon, but I know that in practice it's always safe to take that. Even taking this into account, Physicians should still have a healthy amount of fluff points without going overboard.

**Resident, CMO, Med Tech**: -2 - For similar reasons to Physician getting decreased points. Without a -2, Resident has the same points as Physician. And CMO already has more points than Physician, this reduction is just to keep them in line with the general point reduction across the board for medical. With Med Tech, you can get the skills to do your job and do it well and still have about 10 points left over, so they're getting a slight reduction as well to bring them in line with other jobs. Keep in mind that with the recent +4 global skill points increase, all of these jobs still have +2 compared to when we started the Rebayse. 

**Scientist**: -2 - Currently as Scientist, you can get the skills to do basically every single aspect of Science (and do it well) and still have approximately 8-12 extra skill points. Given that mastering every aspect of your department is basically inherently fluff, this gives Scientists a ton of _arguably_ fluff skill points, a -2 tones that down a little bit and still leaves them with 6-10 points after mastering basically every aspect of their department. Keep in mind that with the recent +4 global skill points increase, you still get +2 skill points compared to when we started the Rebayse.

**Combat Technician**: -2 - This was briefly explained in the Squad Lead changes, but CT currently has an insane amount of skill points and really good starting/guaranteed skills. This tones that down and lessens the gap between SL and CT. Keep in mind that CT still has overall more total skill points than SL even after these changes, but the gap is much, much smaller. 

**Bridge Officer**: -2 - +2 skill points on top of the global skill point increase was a tad much for BO. Inherently the job is not skill intensive, given that the skills required to do your job is heavily up in the air. Aside from maybe Trained Science by default. BO's currently have 30 points to throw around as they wish, which they don't entirely need. A -2 increase still allows them to take plenty of skills but makes for slightly harder decisions and less fluff points at the end. Keep in mind that with the recent +4 global skill increase, and the fact that BO's got an extra +2 on top of that, BO's still have +4 points compared to when we started the Rebayse. 

**PADV**: -6 - You might be asking why PADV gets such a huge reduction in points compared to everyone else. [The answer can be seen in this picture.](https://gyazo.com/825dc7bd999cb02dfcec559f0d03880d) I genuinely have no idea who thought this was needed, but a -6 _minimum_ is required to bring this job in line with others. They still have 32 spare points to spend as they wish after this PR, which is arguably more than enough or too much as is. 