### PR TITLE
Paperwork and lighting related map tweaks

### DIFF
--- a/html/changelogs/hekzder-PR-225.yml
+++ b/html/changelogs/hekzder-PR-225.yml
@@ -1,0 +1,9 @@
+author: Hekzder
+delete-after: True
+changes: 
+  - maptweak: "Adds lights to various spots around D1 and B deck to fix dark spots."
+  - maptweak: "Replaces coffee dispenser in SMC SEA office with a disposals chute, as well as gives them copies of the same books the NTEF SEA has, and a light in the western part of their office."
+  - maptweak: "Gives the PADV a disposals chute, photocopier, shredder, and paper bin. Loses his tea set and a chair outside of his office in exchange."
+  - maptweak: "SGR had some of their tool related things moved to their back room but got a photocopier and shredder as a result."
+  - maptweak: "Adds a photocopier and shredder to the Medical exam room, and a shredder to the Counselor's office."
+  - maptweak: "Adds a photocopier to the Polyp."

--- a/html/changelogs/hekzder-PR-225.yml
+++ b/html/changelogs/hekzder-PR-225.yml
@@ -2,8 +2,10 @@ author: Hekzder
 delete-after: True
 changes: 
   - maptweak: "Adds lights to various spots around D1 and B deck to fix dark spots."
-  - maptweak: "Replaces coffee dispenser in SMC SEA office with a disposals chute, as well as gives them copies of the same books the NTEF SEA has, and a light in the western part of their office."
-  - maptweak: "Gives the PADV a disposals chute, photocopier, shredder, and paper bin. Loses his tea set and a chair outside of his office in exchange."
+  - maptweak: "Replaces coffee dispenser in SMC SEA office with a disposals chute, gives them the same bookcase the NTEF SEA has, a light in the western part of their office, an overall office expansion, a photocopier, shredder, and a potted plant."
+  - maptweak: "Gives the PADV a disposals chute, photocopier, shredder, paper bin, and a couple folders. Loses his tea set and a chair outside of his office in exchange."
   - maptweak: "SGR had some of their tool related things moved to their back room but got a photocopier and shredder as a result."
-  - maptweak: "Adds a photocopier and shredder to the Medical exam room, and a shredder to the Counselor's office."
+  - maptweak: "Adds a photocopier, shredder, and a wall mounted filing cabinet to the Medical exam room, and a shredder to the Counselor's office."
   - maptweak: "Adds a photocopier to the Polyp."
+  - maptweak: "Adds a photocopier and shredder to the NTEF SEA office, changes his filing cabinet drawer to wall-mounted to save space."
+  - maptweak: "Adds an ATM north of the PADV office and between the Medical exam room and Counselor's office."

--- a/html/changelogs/hekzder-PR-225.yml
+++ b/html/changelogs/hekzder-PR-225.yml
@@ -9,3 +9,4 @@ changes:
   - maptweak: "Adds a photocopier to the Polyp."
   - maptweak: "Adds a photocopier and shredder to the NTEF SEA office, changes his filing cabinet drawer to wall-mounted to save space."
   - maptweak: "Adds an ATM north of the PADV office and between the Medical exam room and Counselor's office."
+  - bugfix: "The SMC SEA's office door control now actually controls his office door, instead of the NTEF SEA's office door."

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -13974,6 +13974,7 @@
 /turf/simulated/floor/plating,
 /area/vacant/bar)
 "Ib" = (
+/obj/machinery/photocopier,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/analysis)
 "Ic" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2571,7 +2571,7 @@
 /obj/machinery/door/airlock/glass/medical{
 	autoset_access = 0;
 	name = "Medical Foyer";
-	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
+	req_access = list(list("ACCESS_MEDICAL","ACCESS_MORGUE","ACCESS_FORENSICS"))
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -3624,6 +3624,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "agq" = (
@@ -4109,6 +4110,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "ahk" = (
@@ -4535,6 +4537,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aie" = (
@@ -4594,6 +4597,7 @@
 /obj/item/toy/desk/newtoncradle{
 	pixel_y = 10
 	},
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/foundation,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/psiadvisor)
 "aii" = (
@@ -4631,19 +4635,20 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "ain" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/teacup,
-/obj/item/weapon/reagent_containers/food/drinks/teapot,
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/teacup,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/psiadvisor)
 "aio" = (
@@ -6191,6 +6196,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aqg" = (
@@ -6893,6 +6901,8 @@
 "aub" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/table/standard,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "auc" = (
@@ -17065,6 +17075,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/carpet/blue,
 /area/medical/counselor)
 "dWA" = (
@@ -20057,10 +20068,6 @@
 "ipc" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/medical_lolli_jar,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /turf/simulated/floor/wood/walnut,
 /area/medical/counselor)
 "iqb" = (
@@ -20106,7 +20113,8 @@
 /area/rnd/development)
 "irV" = (
 /obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/foundation,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/psiadvisor)
 "isb" = (
@@ -20480,10 +20488,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "iMW" = (
-/obj/structure/bed/chair/padded/blue{
-	dir = 4;
-	icon_state = "chair_preview"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
@@ -20925,6 +20929,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "jnd" = (
@@ -21658,6 +21663,11 @@
 /area/medical/surgery2)
 "jYZ" = (
 /obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
 /turf/simulated/floor/wood/walnut,
 /area/medical/counselor)
 "jZb" = (
@@ -23367,6 +23377,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"lWO" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/center)
 "lYa" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9;
@@ -23997,10 +24015,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atm{
-	pixel_x = 32
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "mGb" = (
@@ -24516,6 +24534,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atm{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
@@ -27672,6 +27693,13 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"qSJ" = (
+/obj/structure/bed/chair/comfy/black,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/psiadvisor)
 "qTX" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
@@ -30308,6 +30336,10 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "twz" = (
+/obj/structure/bed/chair/padded/blue{
+	dir = 4;
+	icon_state = "chair_preview"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "txb" = (
@@ -30682,9 +30714,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -30697,6 +30726,10 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
@@ -30802,6 +30835,11 @@
 /area/maintenance/firstdeck/aftstarboard)
 "uuS" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "uvj" = (
@@ -31295,8 +31333,6 @@
 /area/command/armoury)
 "vnC" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -31311,6 +31347,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "vpj" = (
@@ -32064,13 +32101,14 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/structure/bed/chair/padded/blue{
-	dir = 4;
-	icon_state = "chair_preview"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "xcW" = (
@@ -49856,7 +49894,7 @@ acF
 acE
 ycz
 ayj
-ure
+lWO
 aJQ
 aBD
 aCU
@@ -58343,7 +58381,7 @@ ruz
 dJp
 ahd
 ahp
-ahJ
+qSJ
 aih
 smJ
 cva

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2571,7 +2571,7 @@
 /obj/machinery/door/airlock/glass/medical{
 	autoset_access = 0;
 	name = "Medical Foyer";
-	req_access = list(list("ACCESS_MEDICAL","ACCESS_MORGUE","ACCESS_FORENSICS"))
+	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden{

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -6903,6 +6903,7 @@
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
+/obj/item/weapon/folder/white,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "auc" = (
@@ -20115,6 +20116,9 @@
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
+/obj/item/weapon/folder/nt,
+/obj/random/clipboard,
+/obj/item/weapon/folder/blue,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/psiadvisor)
 "isb" = (
@@ -21668,6 +21672,7 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/pen,
+/obj/random/clipboard,
 /turf/simulated/floor/wood/walnut,
 /area/medical/counselor)
 "jZb" = (
@@ -22437,6 +22442,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"kRr" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/machinery/atm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "kSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23278,6 +23292,9 @@
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/computer/modular/preset/medical{
 	dir = 8
+	},
+/obj/structure/filingcabinet/wallcabinet{
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
@@ -25412,6 +25429,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/random/clipboard,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "onM" = (
@@ -26854,6 +26872,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/wing)
+"pYB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/rnd/development)
 "pZb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29267,6 +29292,7 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "ssb" = (
@@ -55959,7 +55985,7 @@ aik
 nHe
 dnx
 ltb
-aii
+pYB
 aik
 jUb
 oUb
@@ -56356,7 +56382,7 @@ nCb
 nCb
 nCb
 nCb
-ivT
+kRr
 hib
 tiz
 aik

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -207,9 +207,9 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -430,6 +430,9 @@
 	icon_state = "intact"
 	},
 /obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "aW" = (
@@ -445,6 +448,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "aY" = (
@@ -4261,16 +4267,8 @@
 /turf/simulated/open,
 /area/hallway/primary/bridge/fore)
 "in" = (
-/obj/structure/sign/directions/engineering{
-	dir = 2;
-	pixel_z = 10
-	},
 /obj/structure/sign/directions/evac{
 	dir = 2
-	},
-/obj/structure/sign/directions/supply{
-	dir = 2;
-	pixel_z = -10
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
@@ -4894,28 +4892,10 @@
 	pixel_y = 3;
 	pixel_z = 0
 	},
-/obj/structure/sign/directions/security{
-	dir = 2;
-	pixel_y = -4;
-	pixel_z = 0
-	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
 "jV" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
-"jW" = (
-/obj/structure/sign/directions/infirmary{
-	dir = 2;
-	pixel_y = -4;
-	pixel_z = 0
-	},
-/obj/structure/sign/directions/science{
-	dir = 2;
-	pixel_y = 3;
-	pixel_z = 0
-	},
-/turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
 "jX" = (
 /obj/structure/cable/green{
@@ -5468,13 +5448,6 @@
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
-"lA" = (
-/obj/structure/sign/warning/high_voltage{
-	dir = 8;
-	icon_state = "shock"
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cmo)
 "lB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -6343,6 +6316,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "ny" = (
@@ -6597,6 +6571,10 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "oe" = (
@@ -6662,6 +6640,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "on" = (
@@ -7079,6 +7058,16 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/turret_protected/ai_outer_chamber)
+"pw" = (
+/obj/effect/floor_decal/corner/blue/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/aft)
 "py" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -7407,10 +7396,8 @@
 /area/bridge)
 "qi" = (
 /obj/effect/floor_decal/corner/blue/three_quarters,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
@@ -8802,6 +8789,15 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/storage/briefcase{
+	pixel_x = 3;
+	pixel_y = 0
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "tA" = (
@@ -9144,6 +9140,15 @@
 	},
 /obj/item/weapon/folder/envelope/rep,
 /obj/item/documents/scgr,
+/obj/item/weapon/pen/retractable/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/weapon/pen/retractable/green,
+/obj/item/weapon/pen/retractable/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "uo" = (
@@ -9247,10 +9252,10 @@
 /area/crew_quarters/heads/cobed)
 "uz" = (
 /obj/structure/table/woodentable/walnut,
-/obj/item/device/flashlight/lamp/green,
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
+/obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "uB" = (
@@ -9819,19 +9824,11 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "vX" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
-	},
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/folder/white,
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "vY" = (
@@ -10170,37 +10167,29 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "wD" = (
-/obj/structure/table/woodentable/walnut,
-/obj/machinery/photocopier/faxmachine/torch{
-	department = "Torch - SolGov Representative"
-	},
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
 	},
 /obj/machinery/light,
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/red,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "wE" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/storage/briefcase{
-	pixel_x = 3;
-	pixel_y = 0
-	},
-/obj/item/weapon/hand_labeler,
-/obj/item/device/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/device/camera{
-	pixel_x = 3;
-	pixel_y = -4
-	},
 /obj/structure/sign/double/icarus/solgovflag/right{
 	dir = 1;
 	icon_state = "solgovflag-right";
 	pixel_z = -32
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "wG" = (
@@ -10872,9 +10861,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/auxsolarbridge)
 "yi" = (
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/secure_closet/sea,
@@ -11534,6 +11520,9 @@
 	pixel_y = -25;
 	req_access = list("ACCESS_TORCH_SENIOR_ADVISOR")
 	},
+/obj/item/weapon/book/manual/military_law,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/solgov_law,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/msea)
 "Aj" = (
@@ -16650,12 +16639,16 @@
 	c_tag = "SMC Senior Enlisted Advisor - Office";
 	dir = 4
 	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/obj/machinery/chemical_dispenser/bar_coffee/full{
-	pixel_y = 3
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Qi" = (
@@ -16888,16 +16881,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/weapon/pen/retractable/green,
-/obj/item/weapon/pen/retractable/red{
-	pixel_x = -1;
-	pixel_y = 3
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - SolGov Representative"
 	},
-/obj/item/weapon/pen/retractable/blue{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/weapon/book/manual/solgov_law,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "QV" = (
@@ -17012,10 +16998,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/weapon/storage/box/glasses/pint,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Ri" = (
@@ -17569,6 +17554,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "SO" = (
@@ -17790,6 +17779,15 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
+"Tp" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/aft)
 "Tr" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -17822,6 +17820,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Tz" = (
@@ -19389,8 +19391,9 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/atm{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -33982,7 +33985,7 @@ in
 kL
 lD
 kL
-lA
+kJ
 Xx
 kJ
 fW
@@ -35190,8 +35193,8 @@ fI
 fI
 fI
 fI
-jW
-kM
+fI
+pw
 nb
 ne
 Ey
@@ -37009,7 +37012,7 @@ kl
 hS
 mU
 zJ
-kU
+Tp
 Bv
 HA
 QL

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -207,10 +207,7 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/junction/yjunction,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "aA" = (
@@ -344,12 +341,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
-"aK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/msea)
 "aL" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "bridgestorage_exit";
@@ -436,6 +427,9 @@
 	icon_state = "intact"
 	},
 /obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "aW" = (
@@ -589,17 +583,18 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "bk" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/machinery/computer/modular/preset/cardslot/command{
+	dir = 8;
+	icon_state = "console"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/item/toy/bosunwhistle,
-/obj/item/sticky_pad/random,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
-/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/msea)
 "bl" = (
@@ -2924,10 +2919,6 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
 "fc" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/blue{
@@ -2942,6 +2933,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "fd" = (
@@ -3225,21 +3217,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"fH" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 8;
-	icon_state = "console"
-	},
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/msea)
 "fI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
@@ -3832,20 +3809,16 @@
 /turf/simulated/wall/titanium,
 /area/aquila/cockpit)
 "hi" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/bed/chair/padded/blue,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "hj" = (
@@ -4852,6 +4825,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
+"jP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/aft)
 "jQ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -5822,17 +5818,20 @@
 /obj/item/weapon/stamp/sea,
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for the office door.";
-	id_tag = "seaforedoor";
-	name = "SEA's Office Door Control";
+	id_tag = "ntefsea_foredoor";
+	name = "NTEF SEA Office Door Control";
 	pixel_x = -6;
 	pixel_y = -25;
 	req_access = list("ACCESS_TORCH_SENIOR_ADVISOR")
 	},
 /obj/machinery/button/windowtint{
-	id = "sea_windows";
+	id = "ntefsea_windows";
 	pixel_x = 9;
 	pixel_y = -24
 	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/sea)
 "mA" = (
@@ -6628,6 +6627,7 @@
 /area/hallway/primary/bridge/aft)
 "ol" = (
 /obj/machinery/door/airlock/sol{
+	id_tag = "smcsea_foredoor";
 	name = "SMC Senior Enlisted Advisor"
 	},
 /obj/machinery/door/firedoor,
@@ -7210,9 +7210,16 @@
 /turf/simulated/open,
 /area/turret_protected/ai_data_chamber)
 "pR" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10;
-	icon_state = "corner_white"
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
@@ -7392,10 +7399,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "qi" = (
-/obj/effect/floor_decal/corner/blue/three_quarters,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "qk" = (
@@ -8394,13 +8404,13 @@
 	icon_state = "0-4"
 	},
 /obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "sea_windows"
+	id = "ntefsea_windows"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/sea)
 "sz" = (
 /obj/machinery/door/airlock/sol{
-	id_tag = "seaforedoor";
+	id_tag = "ntefsea_foredoor";
 	name = "NTEF Senior Enlisted Advisor";
 	secured_wires = 1
 	},
@@ -8684,7 +8694,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/obj/structure/flora/pottedplant/unusual,
+/obj/machinery/photocopier,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "to" = (
@@ -9517,6 +9527,7 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/pen,
+/obj/item/weapon/material/clipboard,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sea)
 "vl" = (
@@ -9524,21 +9535,16 @@
 	name = "plastic table frame"
 	},
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/structure/filingcabinet/wallcabinet{
+	pixel_x = 26;
+	step_x = 0
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sea)
 "vm" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
-	},
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/folder/white,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/weapon/material/clipboard,
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
 "vn" = (
@@ -10858,9 +10864,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/auxsolarbridge)
 "yi" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/secure_closet/sea,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "yk" = (
@@ -10971,24 +10978,6 @@
 	},
 /turf/space,
 /area/space)
-"yD" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/photocopier/faxmachine/torch{
-	department = "Torch - Senior Enlisted Advisor"
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Senior Enlisted Advisor's Desk";
-	departmentType = 6;
-	name = "Senior Enlisted Advisor RC";
-	pixel_x = 0;
-	pixel_y = -34
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/msea)
 "yE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -11248,14 +11237,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
-"zz" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/msea)
 "zC" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/PDAs{
@@ -11504,23 +11485,11 @@
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
 "Ai" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/structure/bed/chair/comfy/blue{
+	dir = 1;
+	icon_state = "comfychair_preview"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/item/weapon/stamp/sea,
-/obj/machinery/button/alternate/door{
-	desc = "A remote control-switch for the office door.";
-	id_tag = "seaforedoor";
-	name = "SEA's Office Door Control";
-	pixel_x = -6;
-	pixel_y = -25;
-	req_access = list("ACCESS_TORCH_SENIOR_ADVISOR")
-	},
-/obj/item/weapon/book/manual/military_law,
-/obj/item/weapon/book/manual/sol_sop,
-/obj/item/weapon/book/manual/solgov_law,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Aj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11622,6 +11591,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Ar" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/msea)
 "Av" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
@@ -11951,6 +11930,17 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
+"Bt" = (
+/obj/structure/closet/secure_closet/sea,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/msea)
 "Bv" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13424,6 +13414,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
+"FZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/aftport)
 "Ga" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10;
@@ -15612,6 +15614,30 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
+"MU" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/stamp/sea,
+/obj/machinery/button/alternate/door{
+	desc = "A remote control-switch for the office door.";
+	id_tag = "smcsea_foredoor";
+	name = "SMC SEA Office Door Control";
+	pixel_x = -6;
+	pixel_y = -25;
+	req_access = list("ACCESS_TORCH_SENIOR_ADVISOR")
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/machinery/button/windowtint{
+	id = "smcsea_windows";
+	pixel_x = 9;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/command/msea)
 "MV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -16402,6 +16428,26 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/turret_protected/ai_data_chamber)
+"Pr" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/toy/bosunwhistle,
+/obj/item/sticky_pad/random,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/command/msea)
 "Pt" = (
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
@@ -16547,7 +16593,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/maintenance)
 "Qc" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "smcsea_windows"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/command/msea)
 "Qd" = (
@@ -16636,14 +16693,11 @@
 	c_tag = "SMC Senior Enlisted Advisor - Office";
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Qi" = (
@@ -16780,17 +16834,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
-"QE" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10;
-	icon_state = "corner_white"
-	},
-/obj/structure/bed/chair/comfy/blue{
-	dir = 1;
-	icon_state = "comfychair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/msea)
 "QF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16993,6 +17036,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/structure/flora/pottedplant/tall,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Ri" = (
@@ -17240,7 +17284,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "sea_windows"
+	id = "ntefsea_windows"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/sea)
@@ -17368,6 +17412,10 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/solgov_law,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/military_law,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Sj" = (
@@ -17958,6 +18006,17 @@
 "TX" = (
 /turf/simulated/wall/prepainted,
 /area/bridge/disciplinary_board_room)
+"TY" = (
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/command/msea)
 "TZ" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -18194,6 +18253,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"UM" = (
+/obj/effect/floor_decal/corner/blue/half,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/aft)
 "UN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
@@ -18986,10 +19050,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Xi" = (
@@ -19413,6 +19473,17 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/command/bridge_quarters)
+"Yu" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "smcsea_windows"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/command/msea)
 "Yw" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -19628,20 +19699,6 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/secure_storage)
-"Zd" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/aftport)
 "Ze" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19682,14 +19739,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "Zh" = (
-/obj/structure/bed/chair/padded/blue,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Zi" = (
@@ -19731,6 +19787,27 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/medical)
+"Zm" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Senior Enlisted Advisor"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Senior Enlisted Advisor's Desk";
+	departmentType = 6;
+	name = "Senior Enlisted Advisor RC";
+	pixel_x = 0;
+	pixel_y = -34
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/command/msea)
 "Zp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19925,6 +20002,7 @@
 	pixel_x = 23;
 	pixel_y = 24
 	},
+/obj/structure/flora/pottedplant/unusual,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "ZT" = (
@@ -35403,7 +35481,7 @@ az
 mY
 CU
 oi
-Zd
+FZ
 oT
 oT
 oT
@@ -35605,7 +35683,7 @@ aV
 ne
 oY
 oY
-aK
+oY
 oY
 oY
 oY
@@ -35803,17 +35881,17 @@ ip
 ja
 DN
 kQ
-aV
-ne
-Qc
+jP
+UM
+Yu
 Qh
 Xh
 di
 qi
 yi
+Bt
 oY
-Bp
-Pc
+oh
 Pc
 Pc
 Tc
@@ -36012,10 +36090,10 @@ Rh
 Rz
 BU
 TQ
-zz
+TQ
+TY
 oY
-Bp
-Pc
+oh
 Pc
 Pc
 Tc
@@ -36214,10 +36292,10 @@ Ty
 Zh
 hi
 pR
-yD
-oY
+TQ
+Zm
 Bp
-Pc
+oh
 Pc
 Pc
 Tc
@@ -36413,13 +36491,13 @@ Bv
 ne
 Zy
 Sh
+TQ
 hU
 Fv
-QE
 Ai
-oY
+MU
 Bp
-Pc
+oh
 Pc
 Pc
 Tc
@@ -36615,11 +36693,11 @@ Bv
 ne
 oY
 Th
+Ar
 Dq
 Uh
-fH
 bk
-oY
+Pr
 Bp
 oh
 oh

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3813,11 +3813,6 @@
 /area/aquila/cockpit)
 "hi" = (
 /obj/structure/bed/chair/padded/blue,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -6641,6 +6636,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "on" = (
@@ -16600,13 +16600,12 @@
 	id = "smcsea_windows"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/command/msea)

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -448,9 +448,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "aY" = (
@@ -4852,6 +4849,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
+"jP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/aft)
 "jQ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -6316,7 +6336,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "ny" = (
@@ -6640,7 +6659,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "on" = (
@@ -16644,11 +16662,11 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Qi" = (
@@ -16997,9 +17015,6 @@
 "Rh" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
@@ -17554,10 +17569,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "SO" = (
@@ -17820,10 +17831,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Tz" = (
@@ -18210,6 +18217,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"UM" = (
+/obj/effect/floor_decal/corner/blue/half,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/aft)
 "UN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
@@ -19425,6 +19437,11 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/command/bridge_quarters)
+"Yu" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/command/msea)
 "Yw" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -35801,9 +35818,9 @@ ip
 ja
 DN
 kQ
-aV
-ne
-Qc
+jP
+UM
+Yu
 Qh
 Xh
 di

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -2933,7 +2933,10 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "fd" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -207,9 +207,9 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -344,6 +344,12 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
+"aK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/command/msea)
 "aL" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "bridgestorage_exit";
@@ -430,9 +436,6 @@
 	icon_state = "intact"
 	},
 /obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "aW" = (
@@ -4849,29 +4852,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"jP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
 "jQ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -6107,7 +6087,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "mY" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -16664,9 +16643,7 @@
 	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Qi" = (
@@ -18217,11 +18194,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"UM" = (
-/obj/effect/floor_decal/corner/blue/half,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
 "UN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
@@ -19014,6 +18986,10 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/msea)
 "Xi" = (
@@ -19437,11 +19413,6 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/command/bridge_quarters)
-"Yu" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/command/msea)
 "Yw" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -19657,6 +19628,20 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/secure_storage)
+"Zd" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/aftport)
 "Ze" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35418,7 +35403,7 @@ az
 mY
 CU
 oi
-oT
+Zd
 oT
 oT
 oT
@@ -35620,7 +35605,7 @@ aV
 ne
 oY
 oY
-oY
+aK
 oY
 oY
 oY
@@ -35818,9 +35803,9 @@ ip
 ja
 DN
 kQ
-jP
-UM
-Yu
+aV
+ne
+Qc
 Qh
 Xh
 di


### PR DESCRIPTION
Basically as the title says. Have screenshots for almost every change, as per usual, DM or @ me on Discord with concerns, suggestions, coping, or whatever else relating to this PR. But I think it's mostly just non-controversial QoL mapping stuff. Mostly helps my fellow paperwork peeps, and those afraid of the dark. This is my first time ever mapping on an actual Space Station/Ship with power and disposals pipes and all that fun stuff, but I don't believe I broke anything in doing so, everything seemed to work fine in testing, disposals included. But feel free to test and proof me before merge. 

### **Bridge Deck Adjustments**

[Lights Change 1](https://gyazo.com/2c58b7d62745c8edb2d05918f94d014a) - Adds multiple lights to the eastern hall so it isn't almost pitch black. This also removed some direction signs that are like four tiles from the stairs and therefore another set of direction signs, I don't think this is a loss.

[Lights Change 2](https://gyazo.com/6d4fdb61a1562b8fd9199bff954b2f5c) - Replaces a redundant ATM that is literally two tiles from another ATM with a light so it isn't as dark.

[Lights Change 3](https://gyazo.com/9a7b130a639932d70ec93a7859841fb0) - Replaces an electricity sign with a light so it isn't as dark.

[SMC SEA Office Change](https://gyazo.com/c655f5021c2a258c294ffbb088e13f1e) - Adds a light to the western half of the SMC SEA office, a disposals chute that he was previously missing, and adds the same bookcase that the NTEF SEA has, legal books included.

The disposal chute and a nice plant replaces the coffee machine and table he had before, but I don't view this as a big loss. Literally no other office on the Dagon has a coffee machine, including the CO, atleast to my knowledge. The SMC SEA doesn't need one either, but he probably does need a disposals chute. 

SMC SEA office now also has a working door button and tinted windows, and was expanded by about five tiles to make room for all of this. 

[NTEF SEA Office Change](https://gyazo.com/94d8a06260d0458ea3e56168bc9732b8) - Sacrifices a filing cabinet drawer in exchange for a photocopier and shredder, wall-mounted filing cabinet and some folders added as a replacement.

[SGR Office Change](https://gyazo.com/477dc902149acfffabd3c3f4345c8771) - Adds a photocopier and shredder to the SGR office, as well as moves some of their tool related things to their back/prep room, mimmicking the CL. Moves the filing cabinet into the corner to compensate and make room. 

### **Deck One Adjustments**

[Light Change](https://gyazo.com/7e7ba7262129bf4c03f0bf6ca847bb42) - Adds a light to this otherwise dim part of the hallway.

[Medical Changes 1](https://gyazo.com/a2efa36b706c236889188b6396defae3) - Adds a photocopier and shredder to the Medical exam room, adds a shredder to the Counselor's office. Medical has no copier or shredder in the entire department, and the Counselor having a shredder for dealing with patient confidentiality documents and such makes sense. 

[Medical Changes 2](https://gyazo.com/d3bcc0cc0594eda33601493d2cad310f) - Also added an ATM in the hall between exam and Counselor's office, and added a wall-mounted filing cabinet and folder to the medical exam room.

[PADV Office Change](https://gyazo.com/768ce0befe60bcd43285d613b4c67045) - Adds a photocopier and shredder to PADV office. Replacing that poor table with the teapot and cups that was probably never used. Replaces a chair outside of his office in that small waiting area with a disposals unit since his office has no disposals unit and there isn't really room to put one in the actual office. 

Also adds a paper bin, pen, and a couple folders. Moves things around on his desk to make room for these additions.

[Security Change](https://gyazo.com/4669d624af338b80dc65062590e0bff5) -  Moves the ATM outside of Sec lobby up a couple tiles to place a light there and make it not so dim, then also places a light outside of the Sec/Command briefing room, because that part of the hall is dark as shit. 

[Research Change](https://gyazo.com/c9aa231c601ba498dc0fcc053a40b7f8) - Added a light right outside of Xenobotany and one on the southern part of the main fabricator room.

### **Deck Five/Polyp Adjustment**

[Photocopier](https://gyazo.com/0cca9da0a4cba880b7ecf567c30989d3) - Adds a photocopier to the anomaly research lab thing per request. The only alternative location was in the research lab across from it, but that would be more of a cramped location to put it, and paperwork is reasonably done in this anomaly lab, there's a paperbin on the table right across from the copier. 