### PR TITLE
Another screwing with lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/med_crate.dm
+++ b/code/game/objects/structures/crates_lockers/med_crate.dm
@@ -1,15 +1,13 @@
 /obj/structure/closet/crate/med_crate/trauma
 	name = "\improper Trauma crate"
-	desc = "A crate with trauma equipment."
+	desc = "A crate with first aid equpiment equipment."
 	closet_appearance = /decl/closet_appearance/crate/medical/trauma
 
 /obj/structure/closet/crate/med_crate/trauma/WillContain()
 	return list(
-		/obj/item/stack/medical/splint = 2,
-		/obj/item/stack/medical/advanced/bruise_pack = 10,
-		/obj/item/weapon/reagent_containers/pill/sugariron = 6,
-		/obj/item/weapon/storage/pill_bottle/paracetamol = 2,
-		/obj/item/weapon/storage/pill_bottle/inaprovaline
+		/obj/item/stack/medical/advanced/bruise_pack = 6,
+		/obj/item/stack/medical/advanced/ointment = 6,
+		/obj/item/weapon/storage/pill_bottle/paracetamol
 		)
 
 /obj/structure/closet/crate/med_crate/burn

--- a/html/changelogs/lamasmaster-PR-238.yml
+++ b/html/changelogs/lamasmaster-PR-238.yml
@@ -6,4 +6,4 @@ changes:
   - tweak: "Nerfs security Trauma crate."
   - maptweak: "Few more decals around brig."
   - tweak: "BC now starts with prybar instead of crowbar in locker."
-  - twear: "Cadet starts with backpack holster belt and combiknife like all the other members now."
+  - tweak: "Cadet starts with backpack holster belt and combiknife like all the other members now."

--- a/html/changelogs/lamasmaster-PR-238.yml
+++ b/html/changelogs/lamasmaster-PR-238.yml
@@ -1,0 +1,9 @@
+author: lamasmaster
+
+delete-after: True
+
+changes: 
+  - tweak: "Nerfs security Trauma crate."
+  - maptweak: "Few more decals around brig."
+  - tweak: "BC now starts with prybar instead of crowbar in locker."
+  - twear: "Cadet starts with backpack holster belt and combiknife like all the other members now."

--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -41,6 +41,7 @@
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/device/flash,
 		/obj/item/weapon/gun/energy/confuseray,
+		/obj/item/gunbox/captain,
 		/obj/item/device/megaphone,
 		/obj/item/weapon/storage/box/ids,
 		/obj/item/weapon/material/clipboard,
@@ -64,6 +65,7 @@
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/device/flash,
 		/obj/item/weapon/gun/energy/confuseray,
+		/obj/item/gunbox/executive,
 		/obj/item/device/megaphone,
 		/obj/item/weapon/storage/box/headset,
 		/obj/item/device/radio/headset/heads/torchexec/alt,
@@ -125,6 +127,7 @@
 		/obj/item/device/radio/headset/bridgeofficer/alt,
 		/obj/item/weapon/storage/belt/general,
 		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/clothing/accessory/storage/holster/thigh,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel/grey)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -54,6 +54,7 @@
 		/obj/item/weapon/storage/firstaid/adv,
 		/obj/item/weapon/storage/box/armband/med,
 		/obj/item/weapon/storage/belt/general,
+		/obj/item/weapon/storage/belt/medical,
 		/obj/item/weapon/material/knife/folding/swiss/officer,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel/med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med)),

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -129,7 +129,7 @@
 		/obj/item/weapon/material/knife/folding/swiss/sec,
 		/obj/item/weapon/crowbar/prybar,
 		/obj/item/device/radio,
-		/obj/item/clothing/mask/gas/half
+		/obj/item/clothing/mask/gas/half,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -127,6 +127,9 @@
 		/obj/item/clothing/gloves/thick,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/weapon/material/knife/folding/swiss/sec,
+		/obj/item/weapon/crowbar/prybar,
+		/obj/item/device/radio,
+		/obj/item/clothing/mask/gas/half
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2477,8 +2477,6 @@
 	pixel_x = 32
 	},
 /obj/structure/closet/secure_closet/security_torch,
-/obj/item/stack/medical/advanced/ointment,
-/obj/item/stack/medical/advanced/bruise_pack,
 /obj/effect/floor_decal/corner/red/mono{
 	color = "#22425c"
 	},
@@ -3008,8 +3006,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "afj" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/brig,
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/security/wing)
 "afk" = (
@@ -5647,13 +5648,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "amb" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet{
+	name = "Secure Evidence Locker";
+	req_access = list("ACCESS_SECURITY")
+	},
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "ami" = (
@@ -6044,15 +6049,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics/office)
 "ape" = (
-/obj/structure/closet/secure_closet{
-	name = "Secure Evidence Locker";
-	req_access = list("ACCESS_SECURITY")
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/camera/network/security{
 	c_tag = "Security Wing - Evidence Storage";
 	dir = 8
 	},
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "apf" = (
@@ -8755,9 +8762,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "aCu" = (
-/obj/item/stack/medical/advanced/ointment,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/weapon/gun/energy/gun/small/secure,
 /obj/structure/closet/secure_closet/security_torch/cadet,
 /obj/effect/floor_decal/corner/red/mono{
 	color = "#22425c"
@@ -9519,7 +9523,6 @@
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/sticky_pad/random,
-/obj/item/weapon/folder/blue,
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "aFU" = (
@@ -10282,10 +10285,6 @@
 "aJo" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/secure_closet/brigchief,
-/obj/item/device/radio,
-/obj/item/weapon/crowbar,
-/obj/item/clothing/mask/gas/half,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24;
@@ -10299,7 +10298,10 @@
 	pixel_y = -28
 	},
 /obj/structure/cable/green,
-/obj/item/gunbox,
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bo)
 "aJp" = (
@@ -10862,8 +10864,11 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/device/radio/headset,
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "aLN" = (
@@ -11343,13 +11348,16 @@
 /turf/simulated/wall/prepainted,
 /area/security/wing)
 "aNL" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/security/wing)
 "aNP" = (
@@ -14683,6 +14691,13 @@
 	color = "#22425c";
 	dir = 9
 	},
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/item/weapon/storage/box/handcuffs,
 /turf/simulated/floor/tiled/dark,
 /area/security/storage)
 "biu" = (
@@ -15648,18 +15663,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "cix" = (
-/obj/machinery/vending/wallmed1{
-	dir = 4;
-	name = "Emergency NanoMed";
-	pixel_x = -30;
-	pixel_y = 0
+/obj/structure/closet{
+	name = "Evidence Closet"
 	},
-/obj/effect/floor_decal/corner/red{
-	color = "#22425c";
-	dir = 9
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/security/wing)
+/area/security/evidence)
 "cjb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16358,8 +16373,6 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security_torch,
-/obj/item/stack/medical/advanced/ointment,
-/obj/item/stack/medical/advanced/bruise_pack,
 /obj/effect/floor_decal/corner/red/mono{
 	color = "#22425c"
 	},
@@ -16497,14 +16510,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
-"dkG" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/secure_closet{
-	name = "Secure Evidence Locker";
-	req_access = list("ACCESS_SECURITY")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/evidence)
 "dkJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19570,6 +19575,7 @@
 	pixel_x = -24;
 	pixel_y = -6
 	},
+/obj/item/weapon/folder/blue,
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "hDV" = (
@@ -22553,10 +22559,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/chargebay)
 "kUt" = (
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "kVb" = (
@@ -23209,6 +23218,10 @@
 /obj/structure/table/standard,
 /obj/item/device/tape/random,
 /obj/item/device/tape/random,
+/obj/effect/floor_decal/corner/red{
+	color = "#22425c";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "lEb" = (
@@ -23284,8 +23297,11 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/random/junk,
 /obj/structure/table/rack,
+/obj/effect/floor_decal/corner/red{
+	color = "#22425c";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "lKn" = (
@@ -23372,7 +23388,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/steel,
 /obj/item/weapon/hand_labeler,
-/obj/item/weapon/storage/box/handcuffs,
 /turf/simulated/floor/tiled/dark,
 /area/security/locker)
 "lWb" = (
@@ -25407,9 +25422,6 @@
 	pixel_x = 22;
 	pixel_y = -10
 	},
-/obj/item/stack/medical/advanced/ointment,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/weapon/gun/energy/gun/small/secure,
 /obj/structure/closet/secure_closet/security_torch/cadet,
 /obj/effect/floor_decal/corner/red/mono{
 	color = "#22425c"
@@ -25930,8 +25942,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/closet/secure_closet/security_torch,
-/obj/item/stack/medical/advanced/ointment,
-/obj/item/stack/medical/advanced/bruise_pack,
 /obj/effect/floor_decal/corner/red/mono{
 	color = "#22425c"
 	},
@@ -27297,6 +27307,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/effect/floor_decal/corner/red{
+	color = "#22425c";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "qyb" = (
@@ -27713,8 +27727,12 @@
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "qSD" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
+/obj/structure/closet/secure_closet{
+	name = "Secure Evidence Locker";
+	req_access = list("ACCESS_SECURITY")
+	},
+/obj/effect/floor_decal/corner/red/mono{
+	color = "#22425c"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
@@ -29165,6 +29183,10 @@
 	dir = 6
 	},
 /obj/structure/filingcabinet,
+/obj/effect/floor_decal/corner/red{
+	color = "#22425c";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "smJ" = (
@@ -29369,8 +29391,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/security_torch,
-/obj/item/stack/medical/advanced/ointment,
-/obj/item/stack/medical/advanced/bruise_pack,
 /obj/effect/floor_decal/corner/red/mono{
 	color = "#22425c"
 	},
@@ -30673,6 +30693,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	color = "#22425c";
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/wing)
@@ -41843,7 +41867,7 @@ mJb
 aLA
 htq
 nlb
-cix
+uJd
 uJd
 qYy
 uJd
@@ -43043,9 +43067,9 @@ ajS
 vMw
 qSD
 amb
-dkG
+kUt
 ape
-amb
+cix
 kUt
 tkr
 xzK

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1205,6 +1205,7 @@
 	pixel_x = 8;
 	pixel_y = -3
 	},
+/obj/random/drinkbottle,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
 "cq" = (
@@ -2401,7 +2402,8 @@
 	name = "plastic table frame"
 	},
 /obj/item/device/flashlight/lamp{
-	pixel_y = 3
+	pixel_x = -3;
+	pixel_y = 2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
@@ -2663,6 +2665,7 @@
 /obj/effect/floor_decal/corner/red/mono{
 	color = "#22425c"
 	},
+/obj/random/maintenance/solgov/clean,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
 "eG" = (
@@ -3178,9 +3181,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "fF" = (
-/obj/structure/flora/pottedplant/smelly{
-	desc = "This is some kind of tropical plant. It reeks of rotten eggs. This one has a hand-painted Nametag on the rim. It reads 'Steve'"
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -3192,6 +3192,7 @@
 /obj/effect/floor_decal/corner/red/mono{
 	color = "#22425c"
 	},
+/obj/structure/flora/pottedplant/smelly,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "fG" = (
@@ -5927,7 +5928,6 @@
 	name = "head of security's locker"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/book/manual/sol_sop,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -5942,7 +5942,6 @@
 	pixel_y = 27;
 	req_access = list("ACCESS_HEAD_OF_SECURITY")
 	},
-/obj/item/gunbox,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "mJ" = (
@@ -6510,9 +6509,6 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/device/binoculars,
-/obj/item/weapon/crowbar/prybar,
-/obj/random/maintenance/solgov/clean,
 /obj/machinery/button/blast_door{
 	desc = "A remote control-switch for shutters.";
 	id_tag = "bridge_checkpoint_shutters";
@@ -7527,12 +7523,11 @@
 "qx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/food/snacks/cookie,
-/obj/item/weapon/reagent_containers/food/snacks/cookie,
-/obj/item/weapon/reagent_containers/food/snacks/cookie,
-/obj/item/weapon/reagent_containers/food/snacks/cookie,
-/obj/item/weapon/reagent_containers/food/snacks/cookie,
 /obj/item/weapon/storage/lunchbox/cat,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "qy" = (
@@ -8774,7 +8769,6 @@
 	pixel_y = 23
 	},
 /obj/structure/closet/secure_closet/sfpagent,
-/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "ty" = (
@@ -8782,7 +8776,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/random/drinkbottle,
 /obj/structure/sign/warning/nosmoking_1{
 	desc = "A warning sign which reads 'NO SMOKING'. Someone has scratched a variety of crude words in gutter across the entire sign.";
 	pixel_x = 0;
@@ -10170,6 +10163,8 @@
 	color = "#22425c";
 	dir = 6
 	},
+/obj/item/weapon/book/manual/military_law,
+/obj/item/weapon/book/manual/sol_sop,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "wD" = (
@@ -11056,8 +11051,6 @@
 /area/security/bridgecheck)
 "za" = (
 /obj/structure/closet/secure_closet/XO,
-/obj/random/drinkbottle,
-/obj/item/gunbox/executive,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
 "zb" = (
@@ -13063,8 +13056,6 @@
 "EP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/closet/secure_closet/CMO_torch,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/book/manual/sol_sop,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
@@ -13149,6 +13140,7 @@
 	pixel_x = -23;
 	pixel_y = -3
 	},
+/obj/item/clothing/mask/gas/half,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "Fg" = (
@@ -13340,7 +13332,6 @@
 /area/hallway/primary/bridge/aft)
 "FL" = (
 /obj/structure/closet/secure_closet/bridgeofficer,
-/obj/item/clothing/accessory/storage/holster/thigh,
 /turf/simulated/floor/carpet/blue,
 /area/command/bridge_quarters)
 "FO" = (
@@ -14931,7 +14922,6 @@
 	pixel_y = 30
 	},
 /obj/item/weapon/aiModule/freeform,
-/obj/item/gunbox/captain,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
 "Ks" = (
@@ -17561,6 +17551,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/random/drinkbottle,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "SM" = (

--- a/modular_boh/code/game/structures/closets/closets.dm
+++ b/modular_boh/code/game/structures/closets/closets.dm
@@ -150,7 +150,7 @@
 		/obj/item/weapon/material/knife/folding/swiss/officer,
 		/obj/item/weapon/storage/belt/holster/security,
 		/obj/item/weapon/storage/belt/security,
-		/obj/item/weapon/gun/energy/gun/small/secure
+		/obj/item/weapon/gun/energy/gun/small/secure,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)

--- a/modular_boh/code/game/structures/closets/closets.dm
+++ b/modular_boh/code/game/structures/closets/closets.dm
@@ -147,7 +147,13 @@
 		/obj/item/clothing/gloves/thick,
 		/obj/item/device/holowarrant,
 		/obj/item/device/flashlight/maglight,
-		/obj/item/weapon/storage/belt/security)
+		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/weapon/storage/belt/holster/security,
+		/obj/item/weapon/storage/belt/security,
+		/obj/item/weapon/gun/energy/gun/small/secure
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec)),
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
+	)
 
 //## VESTA.BAY # SEA MARINE ###################
 


### PR DESCRIPTION
Nerfs security Trauma crate.
Moves all equipment from map into actual lockers (doesn´t really affect anything).
Few more decals around brig.
BC now starts with prybar instead of crowbar in locker.
Cadet starts with backpack holster belt and combiknife like all the other members now.