### PR TITLE
Off-ship Love

### DIFF
--- a/html/changelogs/hekzder-PR-246.yml
+++ b/html/changelogs/hekzder-PR-246.yml
@@ -1,0 +1,9 @@
+author: Hekzder
+delete-after: True
+changes: 
+  - rscadd: "Added body scanner to Bearcat and Established Colony."
+  - rscadd: "Added a role slot to Established Colony and Ship Colony, added two role slots to Bearcat."
+  - rscadd: "Added two more voidsuits and one more jetpack to compensate for more roles on the Bearcat."
+  - tweak: "Bearcat members, Colonists, and Crashed Survivors now have better minimum skills but less free skill points to spend. All roles have an overall net increase in skill points."
+  - rscadd: "Specialization alt-titles for medical and engineering to Bearcat and Colonies."
+  - tweak: "Ship colony spawn weight slightly decreased, established colony spawn weight slightly increased."

--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -556,6 +556,7 @@
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/green,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/crew/dorms1)
 "bi" = (
@@ -1140,6 +1141,7 @@
 	icon_state = "corner_white"
 	},
 /obj/item/weapon/bedsheet/ce,
+/obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/crew/dorms2)
 "cl" = (
@@ -1633,6 +1635,7 @@
 /obj/structure/sign/poster{
 	pixel_y = 32
 	},
+/obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/crew/dorms3)
 "dk" = (
@@ -1875,6 +1878,7 @@
 /obj/structure/curtain/open/bed,
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/brown,
+/obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/crew/dorms3)
 "dH" = (
@@ -2112,7 +2116,6 @@
 /area/ship/scrap/maintenance/techstorage)
 "ec" = (
 /obj/item/weapon/stock_parts/circuitboard/helm,
-/obj/item/weapon/stock_parts/circuitboard/unary_atmos/cooler,
 /obj/structure/table/rack,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5;
@@ -2123,16 +2126,17 @@
 	req_access = newlist()
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/weapon/stock_parts/circuitboard/autolathe,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/techstorage)
 "ed" = (
-/obj/item/weapon/stock_parts/circuitboard/autolathe,
-/obj/item/weapon/stock_parts/circuitboard/unary_atmos/heater,
-/obj/structure/table/rack,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5;
 	icon_state = "corner_white"
 	},
+/obj/structure/table/rack,
+/obj/item/weapon/stock_parts/circuitboard/unary_atmos/cooler,
+/obj/item/weapon/stock_parts/circuitboard/unary_atmos/heater,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/techstorage)
 "ee" = (
@@ -2221,13 +2225,11 @@
 /obj/machinery/power/apc/derelict{
 	dir = 1
 	},
-/obj/structure/table/rack,
-/obj/item/weapon/tank/jetpack/oxygen,
-/obj/item/weapon/tank/jetpack/oxygen,
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/suit_storage_unit/engineering/salvage/bearcat,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "el" = (
@@ -2622,6 +2624,7 @@
 	dir = 8;
 	level = 2
 	},
+/obj/machinery/suit_storage_unit/engineering/salvage/bearcat,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/eva)
 "eQ" = (
@@ -2673,6 +2676,9 @@
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	pixel_y = -32
 	},
+/obj/item/weapon/tank/jetpack/oxygen,
+/obj/item/weapon/tank/jetpack/oxygen,
+/obj/item/weapon/tank/jetpack/oxygen,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "eU" = (
@@ -2719,6 +2725,7 @@
 	icon_state = "corner_white"
 	},
 /obj/item/weapon/bedsheet/red,
+/obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/crew/dorms2)
 "gb" = (
@@ -2795,6 +2802,7 @@
 /obj/structure/curtain/open/bed,
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/brown,
+/obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/crew/dorms1)
 "vY" = (

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -1703,7 +1703,6 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/cryo)
 "dg" = (
@@ -1976,17 +1975,11 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/hallway/port)
 "dI" = (
-/obj/structure/closet/crate,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner/beige{
 	dir = 9;
 	icon_state = "corner_white"
 	},
-/obj/random/shoes,
-/obj/random/shoes,
-/obj/random/hat,
-/obj/random/hat,
-/obj/random/masks,
 /obj/machinery/light/small{
 	dir = 1;
 	icon_state = "bulb1"
@@ -2050,23 +2043,19 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
 "dP" = (
-/obj/item/roller,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
 "dQ" = (
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	pixel_y = 32
 	},
-/obj/item/weapon/bedsheet/medical,
-/obj/structure/curtain/open/privacy,
-/obj/structure/bed/padded,
-/obj/item/clothing/accessory/stethoscope,
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24;
 	req_access = newlist()
 	},
+/obj/machinery/bodyscanner,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
 "dR" = (
@@ -2153,6 +2142,12 @@
 	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/random/hat,
+/obj/random/hat,
+/obj/random/shoes,
+/obj/random/shoes,
+/obj/random/masks,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/cargo)
 "dY" = (
@@ -2543,6 +2538,8 @@
 /obj/item/weapon/glass_extra/straw,
 /obj/item/toy/therapy_blue,
 /obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/roller,
+/obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
 "ez" = (
@@ -4433,6 +4430,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/engineering)
 "hD" = (

--- a/maps/away/bearcat/bearcat_jobs.dm
+++ b/maps/away/bearcat/bearcat_jobs.dm
@@ -6,15 +6,34 @@
 	info = "Your ship has suffered a catastrophic amount of damage, leaving it dark and crippled in the depths of \
 	unexplored space. The Captain is dead, leaving you, previously the First Mate in charge. Organize what's left of \
 	your crew, and maybe you'll be able to survive long enough to be rescued."
+	min_skill = list(	SKILL_ANATOMY = SKILL_BASIC,
+						SKILL_MEDICAL = SKILL_BASIC,
+						SKILL_EVA = SKILL_ADEPT,
+						SKILL_WEAPONS = SKILL_ADEPT,
+						SKILL_COMBAT = SKILL_BASIC,
+						SKILL_PILOT = SKILL_ADEPT,
+						SKILL_ELECTRICAL = SKILL_BASIC,
+						SKILL_FINANCE = SKILL_BASIC,
+						SKILL_BUREAUCRACY = SKILL_BASIC)
+	skill_points = 16
 
 /datum/job/submap/bearcat_crewman
 	title = "Independant Crewman"
 	supervisors = "the Captain"
-	total_positions = 3
+	alt_titles = list(
+		"Independent Doctor",
+		"Independent Engineer")
+	total_positions = 5
 	outfit_type = /decl/hierarchy/outfit/job/bearcat/crew
 	info = "Your ship has suffered a catastrophic amount of damage, leaving it dark and crippled in the depths of \
 	unexplored space. Work together with the Acting Captain and what's left of the crew, and maybe you'll be able \
 	to survive long enough to be rescued."
+	min_skill = list(	SKILL_ANATOMY = SKILL_BASIC,
+						SKILL_MEDICAL = SKILL_BASIC,
+						SKILL_EVA = SKILL_ADEPT,
+						SKILL_WEAPONS = SKILL_BASIC,
+						SKILL_ELECTRICAL = SKILL_BASIC)
+	skill_points = 18
 
 #define BEARCAT_OUTFIT_JOB_NAME(job_name) ("Bearcat - Job - " + job_name)
 

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -26,6 +26,10 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	info = "Your ship has been destroyed by a terrible disaster."
 	outfit_type = /decl/hierarchy/outfit/job/survivor
 	total_positions = 3
+	min_skill = list(	SKILL_ANATOMY = SKILL_BASIC,
+						SKILL_MEDICAL = SKILL_BASIC,
+						SKILL_EVA = SKILL_BASIC)
+	skill_points = 22
 
 /decl/hierarchy/outfit/job/survivor
 	name = OUTFIT_JOB_NAME("Survivor")

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -1950,10 +1950,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/engineering)
 "ea" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/storage/box/syringes,
-/obj/item/weapon/storage/box/autoinjectors,
-/obj/item/weapon/storage/box/autoinjectors,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -1963,6 +1959,10 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/bodyscanner{
+	dir = 1;
+	icon_state = "body_scanner_0"
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/colony/medbay)
@@ -2449,6 +2449,9 @@
 /obj/item/weapon/storage/pill_bottle/spaceacillin,
 /obj/item/weapon/storage/pill_bottle/antidexafen,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/storage/box/autoinjectors,
+/obj/item/weapon/storage/box/autoinjectors,
+/obj/item/weapon/storage/box/syringes,
 /turf/simulated/floor/tiled/white,
 /area/map_template/colony/medbay)
 "eP" = (

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -12,7 +12,7 @@
 	apc_test_exempt_areas = list(
 		/area/map_template/colony/mineralprocessing = NO_SCRUBBER|NO_VENT
 	)
-	spawn_weight = 0.2
+	spawn_weight = 0.3
 
 /decl/submap_archetype/playablecolony
 	descriptor = "established colony"
@@ -20,9 +20,20 @@
 
 /datum/job/submap/colonist
 	title = "Colonist"
+	supervisors = "the trust of your fellow Colonists"
 	info = "You are a Colonist, living on the rim of explored, let alone inhabited, space in a reconstructed shelter made from the very ship that took you here."
-	total_positions = 4
+	alt_titles = list(
+		"Colony Engineer",
+		"Colony Doctor")
+	total_positions = 5
 	outfit_type = /decl/hierarchy/outfit/job/colonist
+	min_skill = list(	SKILL_CONSTRUCTION = SKILL_BASIC,
+						SKILL_ANATOMY = SKILL_BASIC,
+						SKILL_MEDICAL = SKILL_BASIC,
+						SKILL_BOTANY = SKILL_BASIC,
+						SKILL_EVA = SKILL_BASIC,
+						SKILL_ELECTRICAL = SKILL_BASIC)
+	skill_points = 20
 
 /decl/hierarchy/outfit/job/colonist
 	name = OUTFIT_JOB_NAME("Colonist")

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
@@ -12,7 +12,7 @@
 	apc_test_exempt_areas = list(
 		/area/map_template/colony2/external = NO_SCRUBBER|NO_VENT
 	)
-	spawn_weight = 0.4
+	spawn_weight = 0.3
 
 /decl/submap_archetype/playablecolony2
 	descriptor = "landed colony ship"
@@ -22,9 +22,19 @@
 	title = "Ship Colonist"
 	supervisors = "the trust of your fellow Colonists"
 	info = "You are a Colonist, living on the rim of explored, let alone inhabited, space in a recently landed colony ship."
-	total_positions = 3
+	alt_titles = list(
+		"Ship Colony Engineer",
+		"Ship Colony Doctor")
+	total_positions = 4
 	outfit_type = /decl/hierarchy/outfit/job/colonist2
-
+	min_skill = list(	SKILL_CONSTRUCTION = SKILL_BASIC,
+						SKILL_ANATOMY = SKILL_BASIC,
+						SKILL_MEDICAL = SKILL_BASIC,
+						SKILL_BOTANY = SKILL_BASIC,
+						SKILL_EVA = SKILL_BASIC,
+						SKILL_ELECTRICAL = SKILL_BASIC)
+	skill_points = 20
+	
 /decl/hierarchy/outfit/job/colonist2
 	name = OUTFIT_JOB_NAME("Colonist2")
 	id_types = list()


### PR DESCRIPTION
Some love for off-ship roles like Colony and Survivor. Due to popular request and seeing first hand the immense pain that some skills can cause. 

[Current Skill Points for both Colony and Survivor are here.](https://gyazo.com/39700de04ee859b70ccbaab7778f9c2f)

[Proposed changes for Colony skill points are here.](https://gyazo.com/464043cb58ccbc29c701a10d66260ec7)

[Proposed changes for Survivor skill points are here.](https://gyazo.com/04599edafd6e82ee95b9e4be85b4e7a9)

Basically, TL;DR is: Colony loses 5 free skill points but gains 13 minimum skill points across various skills that make sense for a Colonist to have and make being a Colony doctor not immense pain. Survivor loses 3 free skill points but gains 9 minimum skill points, mainly just to make being a Survivor doctor not immense pain.

Other changes include some specialization based alt-titles for Colony to complement the fact that Colony doctors are now viable without being incredibly painful. An increase in one slot for both Colony and Ship Colony, since Colony has 5 beds and spawns but only 4 slots, and Ship Colony has 4 beds and spawns but only 3 slots. Also an equalization of the spawn weight of Colony and Ship Colony, both to 0.3, from 0.2 and 0.4 respectively. 

I'm willing to change pretty much anything in this PR based on feedback, more or less alt-titles, adjusted skills, etc. But I do think _something_ should be done about off-ship skills even if this is not **the exact** way to go.