### PR TITLE
Fixes Lab Technician access

### DIFF
--- a/modular_boh/code/modules/jobs/outfits/vesta_outfits.dm
+++ b/modular_boh/code/modules/jobs/outfits/vesta_outfits.dm
@@ -142,12 +142,12 @@
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/combat/marine/medical
 	shoes = /obj/item/clothing/shoes/dutyboots
 
-/decl/hierarchy/outfit/job/torch/crew/medical/chemist
+/decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist/fleet
 	name = OUTFIT_JOB_NAME("Laboratory Technician - Fleet")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/medical
 	shoes = /obj/item/clothing/shoes/dutyboots
 
-/decl/hierarchy/outfit/job/torch/crew/medical/chemist/marine
+/decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist/marine
 	name = OUTFIT_JOB_NAME("Laboratory Technician - Marine")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/combat/marine/medical
 	shoes = /obj/item/clothing/shoes/dutyboots

--- a/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
+++ b/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
@@ -248,8 +248,8 @@
 /datum/job/chemist
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/chemist,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/medical/chemist/marine
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
NTEF and SMC Lab Technicians now have normal medical access again.