### PR TITLE
The Fun Rank Overhaul

### DIFF
--- a/modular_boh/code/game/ranks/vesta_ranks.dm
+++ b/modular_boh/code/game/ranks/vesta_ranks.dm
@@ -215,7 +215,8 @@
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/fleet/o5,
-		/datum/mil_rank/fleet/o6
+		/datum/mil_rank/fleet/o6,
+		/datum/mil_rank/fleet/o7
 	)
 
 

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -332,6 +332,9 @@ var/const/INF               =(1<<11)
 		/datum/mil_rank/fleet/e7,
 		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/fleet/w2,
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/civ/contractor
 		)
 	min_skill = list(   SKILL_COMPUTER		= SKILL_ADEPT,

--- a/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
+++ b/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
@@ -136,10 +136,12 @@
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/marine_corps/e3,
 		/datum/mil_rank/marine_corps/e4,
 		/datum/mil_rank/marine_corps/e5,
 		/datum/mil_rank/marine_corps/e6,
+		/datum/mil_rank/marine_corps/w1,
 		/datum/mil_rank/civ/contractor
 	)
 
@@ -477,12 +479,14 @@
 		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/fleet/w2,
 		/datum/mil_rank/fleet/w3,
+		/datum/mil_rank/fleet/w4,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/marine_corps/w1,
 		/datum/mil_rank/marine_corps/w2,
 		/datum/mil_rank/marine_corps/w3,
+		/datum/mil_rank/marine_corps/w4,
 		/datum/mil_rank/marine_corps/o2,
 		/datum/mil_rank/marine_corps/o3,
 		/datum/mil_rank/marine_corps/o4

--- a/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
+++ b/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
@@ -9,8 +9,7 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o5,
-		/datum/mil_rank/fleet/o6,
-		/datum/mil_rank/fleet/o7
+		/datum/mil_rank/fleet/o6
 	)
 
 /datum/job/hop

--- a/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
+++ b/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
@@ -371,11 +371,18 @@
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/fleet/e7,
+		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/private_security/pcrc_agt = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/pcrc_agent,
 		/datum/mil_rank/sol/agent,
 		/datum/mil_rank/marine_corps/e4,
-		/datum/mil_rank/marine_corps/e5
+		/datum/mil_rank/marine_corps/e5,
+		/datum/mil_rank/marine_corps/e6,
+		/datum/mil_rank/marine_corps/e7,
+		/datum/mil_rank/marine_corps/w1
+
 	)
 
 /datum/job/officer
@@ -394,9 +401,11 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/marine_corps/e3,
 		/datum/mil_rank/marine_corps/e4,
 		/datum/mil_rank/marine_corps/e5,
+		/datum/mil_rank/marine_corps/e6,
 		/datum/mil_rank/private_security/pcrc = /decl/hierarchy/outfit/job/torch/crew/security/maa/pcrc,
 		/datum/mil_rank/private_security/saare = /decl/hierarchy/outfit/job/torch/crew/security/maa/saare
 	)
@@ -429,13 +438,16 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/fleet/e1,
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/marine_corps/e1,
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3,
-		/datum/mil_rank/marine_corps/e4
+		/datum/mil_rank/marine_corps/e4,
+		/datum/mil_rank/marine_corps/e5
 	)
 
 /datum/job/chef
@@ -449,9 +461,11 @@
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3,
-		/datum/mil_rank/marine_corps/e4
+		/datum/mil_rank/marine_corps/e4,
+		/datum/mil_rank/marine_corps/e5
 	)
 
 /datum/job/crew
@@ -463,9 +477,11 @@
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3,
 		/datum/mil_rank/marine_corps/e4,
+		/datum/mil_rank/marine_corps/e5
 	)
 /***/
 
@@ -503,10 +519,14 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3,
 		/datum/mil_rank/marine_corps/e4,
 		/datum/mil_rank/marine_corps/e5,
+		/datum/mil_rank/marine_corps/e6,
+		/datum/mil_rank/marine_corps/w1,
 		/datum/mil_rank/civ/contractor
 	)
 
@@ -519,7 +539,9 @@
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
-		/datum/mil_rank/fleet/e5
+		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/fleet/w1
 	)
 /***/
 

--- a/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
+++ b/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
@@ -8,7 +8,9 @@
 		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/command/CO/fleet
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/o6
+		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/fleet/o6,
+		/datum/mil_rank/fleet/o7
 	)
 
 /datum/job/hop
@@ -17,8 +19,10 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/XO/marine
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/marine_corps/o3,
 		/datum/mil_rank/marine_corps/o4,
 		/datum/mil_rank/marine_corps/o5
 	)
@@ -28,6 +32,7 @@
 		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/research/fleet/cso
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/fleet/o5
 	)
@@ -38,8 +43,10 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/cmo/marine
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/marine_corps/o3,
 		/datum/mil_rank/marine_corps/o4,
 		/datum/mil_rank/marine_corps/o5
 	)
@@ -50,10 +57,14 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer/marine
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
+		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/marine_corps/o2,
 		/datum/mil_rank/marine_corps/o3,
-		/datum/mil_rank/marine_corps/o4
+		/datum/mil_rank/marine_corps/o4,
+		/datum/mil_rank/marine_corps/o5
 	)
 
 /datum/job/hos
@@ -62,10 +73,14 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/cos/marine
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4,
+		/datum/mil_rank/marine_corps/o1,
 		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3
+		/datum/mil_rank/marine_corps/o3,
+		/datum/mil_rank/marine_corps/o4
 	)
 
 /datum/job/bridgeofficer
@@ -81,8 +96,12 @@
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/marine_corps/o1,
-		/datum/mil_rank/marine_corps/o2
+		/datum/mil_rank/marine_corps/o2,
+		/datum/mil_rank/marine_corps/o3,
+		/datum/mil_rank/marine_corps/o4
 	)
 /***/
 
@@ -143,7 +162,8 @@
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4
 	)
 
 /datum/job/nt_pilot
@@ -185,8 +205,10 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/medical/senior/marine
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
+		/datum/mil_rank/marine_corps/o2,
 		/datum/mil_rank/marine_corps/o3,
 		/datum/mil_rank/marine_corps/o4,
 		/datum/mil_rank/civ/contractor
@@ -201,8 +223,10 @@
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/marine_corps/o1,
 		/datum/mil_rank/marine_corps/o2,
+		/datum/mil_rank/marine_corps/o3,
 		/datum/mil_rank/civ/contractor
 	)
 
@@ -244,8 +268,10 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/marine_corps/o1,
 		/datum/mil_rank/marine_corps/o2,
 		/datum/mil_rank/marine_corps/o3
 	)
@@ -385,8 +411,12 @@
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/marine_corps/o1,
-		/datum/mil_rank/marine_corps/o2
+		/datum/mil_rank/marine_corps/o2,
+		/datum/mil_rank/marine_corps/o3,
+		/datum/mil_rank/marine_corps/o4
 	)
 
 /datum/job/janitor
@@ -449,11 +479,13 @@
 		/datum/mil_rank/fleet/w3,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/marine_corps/w1,
 		/datum/mil_rank/marine_corps/w2,
 		/datum/mil_rank/marine_corps/w3,
 		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3
+		/datum/mil_rank/marine_corps/o3,
+		/datum/mil_rank/marine_corps/o4
 	)
 
 /datum/job/cargo_tech

--- a/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
+++ b/modular_boh/code/modules/jobs/torch_jobs_vesta.dm
@@ -9,7 +9,8 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o5,
-		/datum/mil_rank/fleet/o6
+		/datum/mil_rank/fleet/o6,
+		/datum/mil_rank/fleet/o7
 	)
 
 /datum/job/hop


### PR DESCRIPTION
To follow the point made by the rank revert as well as the most recent announcement, and ensure the new principle of fun and roleplay freedom is applied consistently, I made this PR to open up a variety of ranks that were previously very limited to allow for more roleplay opportunities and more fun. 

**Captain can now be O-5, O-6, and O-7** O-5 to allow for the roleplay freedom to RP as a veteran O-5 put in charge of the Dagon, which is not an incredibly large ship and not outside the realm of possibility. O-7 to allow for the roleplay freedom to RP as a Commodore who took immense interest in the very important mission and strategic importance of the Dagon and wanted to assist directly in it's mission.

**XO can now be O-3, O-4, and O-5.** O-3 to allow for the ability to roleplay as a very junior level Executive Officer, likely their first assignment and such, and as previously mentioned, the Dagon isn't an incredibly large ship, thus more junior level leading officers makes sense. 

**CMO and CSO can now be O-3, O-4, and O-5** to allow for the ability to roleplay as a very junior level department head, likely their first assignment and such, and as previously mentioned, the Dagon isn't an incredibly large ship, thus more junior level leading officers makes sense. 

**CE can now be O-2, O-3, O-4, and O-5.** O-2 is to allow for the roleplay freedom of those wanting to be O-2s, since they previously had that roleplay freedom taken away from them, my apologies. O-5 is to allow for the roleplay opportunity of being an incredibly seasoned and specialized engineer promoted to Commander as a result of long service and hard work. 

**CoS can now be O-1, O-2, O-3, and O-4**. O-1 is to allow fresh faced CoS' leading a department of only Enlisted anyways, likely the same as above explanations, first assignment. O-4 is to allow the opposite, grizzled and hardened CoS' leading their department for probably close to a decade. 

**BO can now be O-1, O-2, O-3, and O-4**. O-3 is for senior level bridge officers to be able to get promotions and still play the role they want to, promotion roleplay is cool and should be _promoted_ more. O-4 is because TGMC has their bridge officer equivalents start at O-4 and I want the roleplay opportunity to play as one of my characters from TGMC. 

**Physicians can now be O-2, Residents can now be O-3. Counselor can now be O-1.** All for similar reasons, to represent a Resident that is maybe a bit slow in the medical learning department, but still on good track for promotions. Physician to represent Physicians that are maybe very good at medical, but not on good track for promotions. And finally to represent a fresh faced Counselor straight out of officer school.

**Pathfinder can now be O-1, O-2, O-3, and O-4.** O-4 Pathfinders represent incredibly grizzled and hardened frontline scientists and exploration leaders, as opposed to the ship side senior leadership of the CSO. 

**Chaplain can now be O-1, O-2, O-3, and O-4.** Mostly to mimmick Bridge Officer ranks and allow for maximum roleplay ability when it comes to playing more senior level chaplains. 

**Deck Chief can now be O-2, O-3, and O-4.** O-4 is to represent grizzled and hardened supply/logistics workers, but on the officer side of things, much like W-3 represents incredibly hardened Enlisted supply workers, given officer status after diligence and hard work.

I am more than open to suggestions or feedback to expand more ranks to allow for more roleplay opportunities moving forward. Because, at the end of the day, if it's not fun, why bother? CL coming after feedback and any potential changes.