### PR TITLE
Expand access to SGR, SFP, CL, APA, and SEA

### DIFF
--- a/html/changelogs/Electric-PR-269.yml
+++ b/html/changelogs/Electric-PR-269.yml
@@ -1,0 +1,6 @@
+
+author: Electric
+delete-after: True
+changes:
+  - tweak: "Expanded access for SGR, CL, and their bodyguards. They all have basic department accesses and can enter the hangar. SGR and CL can swipe for code red."
+  - tweak: "SEA has security door access."

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -384,7 +384,7 @@ var/const/INF               =(1<<11)
 	access = list( //Same access as the SolGov Representative + Private access to their equipment locker
 		access_representative, access_representative_guard, access_bridge, access_torch_fax, access_solgov_crew,
 		access_radio_comm,
-		access_security, access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar, access_infantry
+		access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar, access_infantry
 	)
 
 	defer_roundstart_spawn = TRUE

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -382,9 +382,9 @@ var/const/INF               =(1<<11)
 	skill_points = 20
 
 	access = list( //Same access as the SolGov Representative + Private access to their equipment locker
-		access_representative, access_representative_guard,
-		access_bridge, access_solgov_crew,
-		access_hangar, access_torch_fax, access_radio_comm
+		access_representative, access_representative_guard, access_bridge, access_torch_fax, access_solgov_crew,
+		access_radio_comm,
+		access_sec_guard, access_security, access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar, access_infantry
 	)
 
 	defer_roundstart_spawn = TRUE
@@ -406,3 +406,35 @@ var/const/INF               =(1<<11)
 			if(M.mind.assigned_role == "SolGov Representative")
 				to_chat(M, SPAN_NOTICE("<b>Your bodyguard, Agent [person.real_name], is present on [GLOB.using_map.full_name].</b>"))
 	..()
+
+/datum/job/liaison
+	access = list(
+		access_liaison, access_bridge, access_torch_fax, access_solgov_crew, access_keycard_auth,
+		access_nanotrasen, access_commissary,
+		access_radio_comm, access_radio_serv,
+		access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar
+	)
+
+/datum/job/bodyguard
+	access = list(
+		access_liaison, access_bridge, access_torch_fax, access_solgov_crew,
+		access_nanotrasen, access_commissary,
+		access_radio_comm, access_radio_serv,
+		access_sec_guard, access_security, access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar
+	)
+
+/datum/job/representative
+	access = list(
+		access_representative, access_bridge, access_torch_fax, access_solgov_crew,
+		access_radio_comm,
+		access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar, access_infantry
+	)
+
+datum/job/sea
+	access = list(
+		access_sec_doors, access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_janitor,
+		access_kitchen, access_cargo, access_RC_announce, access_keycard_auth, access_aquila, access_guppy_helm,
+		access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_torch_fax,
+		access_radio_comm, access_radio_eng, access_radio_med, access_radio_sec, access_radio_serv, access_radio_sup, access_radio_exp
+		)

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -384,7 +384,7 @@ var/const/INF               =(1<<11)
 	access = list( //Same access as the SolGov Representative + Private access to their equipment locker
 		access_representative, access_representative_guard, access_bridge, access_torch_fax, access_solgov_crew,
 		access_radio_comm,
-		access_sec_guard, access_security, access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar, access_infantry
+		access_security, access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar, access_infantry
 	)
 
 	defer_roundstart_spawn = TRUE

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -420,7 +420,7 @@ var/const/INF               =(1<<11)
 		access_liaison, access_bridge, access_torch_fax, access_solgov_crew,
 		access_nanotrasen, access_commissary,
 		access_radio_comm, access_radio_serv,
-		access_sec_guard, access_security, access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar
+		access_security, access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar
 	)
 
 /datum/job/representative

--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -420,7 +420,7 @@ var/const/INF               =(1<<11)
 		access_liaison, access_bridge, access_torch_fax, access_solgov_crew,
 		access_nanotrasen, access_commissary,
 		access_radio_comm, access_radio_serv,
-		access_security, access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar
+		access_sec_doors, access_medical, access_research, access_cargo, access_engine, access_hangar
 	)
 
 /datum/job/representative


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
General accesses granted to SGR and CL: security doors, medical doors, engineering doors, supply, and the hangar.
Their bodyguards have the same access, plus security equipment and security lockers (they already had sec locker access).
SGR and CL are also given key card authorization, for changing ship alert levels.

Both SEAs are given security door access as well as I was told on Discord they provide legal counsel for enlisted. This would allow them to attend interrogations and processing. Same for SGR and CL for their respective citizens/employees.

Will include a changelog later tonight or tomorrow.