### PR TITLE
Adds item pushing/sliding on table surfaces

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -15,14 +15,14 @@
 		return FALSE // should stop you from dragging through windows
 	return TRUE
 
-/atom/MouseDrop(atom/over)
+/atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	if(!usr || !over) return
 	if(!Adjacent(usr) || !over.Adjacent(usr)) return // should stop you from dragging through windows
 
 	spawn(0)
-		over.MouseDrop_T(src,usr)
+		over.MouseDrop_T(src,usr,src_location,over_location,src_control,over_control,params)
 	return
 
 // Receive a mouse drop
-/atom/proc/MouseDrop_T(atom/dropping, mob/user)
+/atom/proc/MouseDrop_T(atom/dropping, mob/user, src_location, over_location, src_control, over_control, params)
 	return

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -1,3 +1,4 @@
+
 /obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1
 	if(istype(mover,/obj/item/projectile))
@@ -63,12 +64,30 @@
 	return 1
 
 
-/obj/structure/table/MouseDrop_T(mob/target, mob/user)
-	if (isrobot(user))
+/obj/structure/table/MouseDrop_T(obj/O as obj, mob/user as mob, src_location, over_location, src_control, over_control, params)
+	if(istype(O.loc, /mob)) //If placing an item
+		if ((!( istype(O, /obj/item/weapon) ) || user.get_active_hand() != O))
+			return ..()
+		if(isrobot(user))
+			return
+		user.unequip_item()
+		if (O.loc != src.loc)
+			step(O, get_dir(O, src))
 		return
-	if (target.loc != loc)
-		step(target, get_dir(target, loc))
-	..()
+
+	else if(istype(O.loc, /turf) && istype(O, /obj/item)) //If pushing an item on the tabletop
+		var/obj/item/I = O
+
+		if(O.CanMouseDrop(loc, user))
+			if(O.w_class <= user.can_pull_size)
+				O.forceMove(loc)
+				auto_align(I, params, TRUE)
+			else
+				to_chat(user, SPAN_WARNING("[I] won't budge!"))
+			return
+
+	return ..()
+
 
 /obj/structure/table/attackby(obj/item/W, mob/user, var/click_params)
 	if (!W) return
@@ -111,7 +130,7 @@ closest to where the cursor has clicked on.
 Note: This proc can be overwritten to allow for different types of auto-alignment.
 */
 /obj/item/var/center_of_mass = "x=16;y=16" //can be null for no exact placement behaviour
-/obj/structure/table/proc/auto_align(obj/item/W, click_params)
+/obj/structure/table/proc/auto_align(obj/item/W, click_params, var/animate = FALSE)
 	if (!W.center_of_mass) // Clothing, material stacks, generally items with large sprites where exact placement would be unhandy.
 		W.pixel_x = rand(-W.randpixel, W.randpixel)
 		W.pixel_y = rand(-W.randpixel, W.randpixel)
@@ -134,8 +153,18 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 
 	var/list/center = cached_key_number_decode(W.center_of_mass)
 
-	W.pixel_x = (CELLSIZE * (cell_x + 0.5)) - center["x"]
-	W.pixel_y = (CELLSIZE * (cell_y + 0.5)) - center["y"]
+	var/target_x = (CELLSIZE * (cell_x + 0.5)) - center["x"]
+	var/target_y = (CELLSIZE * (cell_y + 0.5)) - center["y"]
+
+	if (animate)
+		var/dist_x = abs(W.pixel_x - target_x)
+		var/dist_y = abs(W.pixel_y - target_y)
+		var/dist = sqrt((dist_x*dist_x)+(dist_y*dist_y))
+
+		animate(W, pixel_x=target_x, pixel_y=target_y,time=dist*0.5)
+	else
+		W.pixel_x = target_x
+		W.pixel_y = target_y
 	W.pixel_z = 0
 
 /obj/structure/table/rack/auto_align(obj/item/W, click_params)

--- a/html/changelogs/wb13-PR-298.yml
+++ b/html/changelogs/wb13-PR-298.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Unknown
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Allows items to be pushed along tabletops by dragging and dropping their sprites."


### PR DESCRIPTION
Allows you to push items along tabletops by dragging and dropping their sprites.
A simple but neat feature for RP and bartending, I reckon.