### PR TITLE
removes the nurse alt-title from medical resident, gives it to physician

### DIFF
--- a/html/changelogs/anconfuzedrock-PR-306.yml
+++ b/html/changelogs/anconfuzedrock-PR-306.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: theunlovedrock
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Nurse is now an alt title for physician instead of medical resident."

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -56,8 +56,6 @@
 	supervisors = "Physicians and the Chief Medical Officer"
 	selection_color = "#013d3b"
 	economic_power = 6
-	alt_titles = list(
-		"Nurse")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/senior
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -11,6 +11,7 @@
 	selection_color = "#013d3b"
 	economic_power = 10
 	alt_titles = list(
+		"Nurse",
 		"Surgeon")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/senior
 	allowed_branches = list(


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Medical resident is a one-slot trainee role which should not be confused as anything else. "Nurse" as an alt title isn't even too accurate to the role, but it can confuse players into thinking of medical resident as something else. Resident is 1-slot because medical is balanced around 2-3 surgeons max and they probably don't have time to train several doctors at once nor is medical stocked for that. There are several problems with someone playing Medical resident as a third doctor/"nurse" with lower responsibilities:
-It effectively means there are three physicians. There is a restrictive cap of 2 physicians for a reason.
-Trainee roles are as much an ooc role as if not more than an ic role, and taking advantage of people being easy on you oocly is bad. see Trainee antags.
-Most importantly, it means that players interested in learning the daunting role of physician aren't able to play. 

I'd considered giving the title nurse to either MT or Physician, but it doesn't feel quite right to me. If a maintainer thinks otherwise I'll add it.
edit:  Lamas suggested me make it for physician so I'm goin with that
