### PR TITLE
Craftable ore box

### DIFF
--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -135,6 +135,7 @@
 	. += new/datum/stack_recipe/stick(src)
 	. += new/datum/stack_recipe/noticeboard(src)
 	. += new/datum/stack_recipe/furniture/table_frame(src)
+	. += new/datum/stack_recipe/furniture/ore_box(src)
 
 /material/wood/mahogany/generate_recipes(var/reinforce_material)
 	. = ..()

--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -238,6 +238,12 @@ ARMCHAIR(yellow)
 	title = "multi-tile airlock assembly"
 	result_type = /obj/structure/door_assembly/multi_tile
 
+/datum/stack_recipe/furniture/ore_box
+	title = "ore box"
+	result_type = /obj/structure/ore_box
+	req_amount = 20
+	time = 50
+
 /datum/stack_recipe/furniture/crate
 	title = "crate"
 	result_type = /obj/structure/closet/crate


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Adds ore boxes to the wooden crafting list. Costs 20 planks. Changelog soon™.