### PR TITLE
Allow tablets to be put in the belt slot

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
@@ -5,7 +5,8 @@
 	icon_state = "tablet"
 	icon_state_unpowered = "tablet"
 	item_state = "tablet"
-
+	slot_flags = SLOT_BELT
+	
 	hardware_flag = PROGRAM_TABLET
 	max_hardware_size = 1
 	w_class = ITEM_SIZE_SMALL


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Add a flag to allow tablets to fit on your belt slot.