### PR TITLE
Adds access restrictions for the engi polytool.

### DIFF
--- a/html/changelogs/vhbraz-PR-317.yml
+++ b/html/changelogs/vhbraz-PR-317.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Vhbraz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The Engi Polytool augment in the loadout screen is now restricted to engineering, research and prospector roles. You can still get an implanted tool from a roboticist as any role after the round starts."

--- a/modular_boh/loadouts/custom_loadouts.dm
+++ b/modular_boh/loadouts/custom_loadouts.dm
@@ -568,6 +568,13 @@ datum/gear/head/ECdepartment/New()
 	display_name = "mechanical polytool - left arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/polytool/engineer/left
 	cost = 4
+	allowed_roles = list(
+		/datum/job/rd, /datum/job/scientist, /datum/job/roboticist, 
+		/datum/job/scientist_assistant, /datum/job/assistant, 
+		/datum/job/senior_scientist, /datum/job/chief_engineer, 
+		/datum/job/senior_engineer, /datum/job/engineer, 
+		/datum/job/engineer_trainee, /datum/job/mining
+	) //Engineering, Research and Prospectors/Salvage Techs.
 
 /datum/gear/augmentation/implanted_toolkit/right
 	display_name = "mechanical polytool - right arm (ROBOTIC)"
@@ -577,6 +584,7 @@ datum/gear/head/ECdepartment/New()
 	display_name = "circuit augment - left arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/simple/circuit/left
 	cost = 4
+	allowed_roles = TECHNICAL_ROLES
 
 /datum/gear/augmentation/implanted_circuitkit/right
 	display_name = "circuit augment - right arm (ROBOTIC)"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Engi Polytool is now restricted to engineering, research, and salvage technician/prospector roles on the loadout menu.
Works fine in testing.
Changelog incoming

This does not mean that you can not get the engi Polytool. This simply means that the ROUNDSTART engi polytool from the loadout tab is now role-locked. If you want one, you'll have to get it from the roboticist.