### PR TITLE
Add aluminum sheets and a powerloader mech to the merchant station

### DIFF
--- a/html/changelogs/Electric-PR-327.yml
+++ b/html/changelogs/Electric-PR-327.yml
@@ -1,0 +1,4 @@
+author: Electric
+delete-after: True
+changes:
+  - maptweak: "Add 200 sheets of aluminum and a powerloader with mech charging bay to the merchant outpost."

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -9948,10 +9948,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/merchant_station)
-"aSS" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
-/area/merchant_station)
 "aST" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/light/small{
@@ -10754,10 +10750,6 @@
 /area/merchant_station)
 "aVu" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
-/area/merchant_station)
-"aVv" = (
-/obj/structure/table/rack,
 /turf/simulated/floor/tiled,
 /area/merchant_station)
 "aVw" = (
@@ -11624,6 +11616,14 @@
 	icon_state = "dark"
 	},
 /area/syndicate_elite_squad)
+"cpC" = (
+/obj/structure/table/rack,
+/obj/item/stack/material/aluminium/fifty,
+/obj/item/stack/material/aluminium/fifty,
+/obj/item/stack/material/aluminium/fifty,
+/obj/item/stack/material/aluminium/fifty,
+/turf/simulated/floor/tiled,
+/area/merchant_station)
 "cqu" = (
 /obj/structure/holostool,
 /obj/effect/floor_decal/beach{
@@ -12490,6 +12490,12 @@
 	},
 /turf/simulated/floor/holofloor/tiled/stone,
 /area/holodeck/source_temple)
+"uJC" = (
+/obj/effect/floor_decal/industrial/warning,
+/mob/living/exosuit/premade/powerloader,
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled,
+/area/merchant_station)
 "uJE" = (
 /obj/effect/floor_decal/stoneborder{
 	dir = 8;
@@ -24553,7 +24559,7 @@ aRt
 aRH
 aPc
 aPc
-aSS
+uJC
 aTq
 aTK
 aPc
@@ -24762,7 +24768,7 @@ aUc
 aPc
 aQN
 aUX
-aVv
+cpC
 aVQ
 aWn
 aMf


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Adds 200 sheets of aluminum and a powerloader with a charger for faster cargo loading.