### PR TITLE
Ports combi-knife extended functionality

### DIFF
--- a/code/game/objects/items/weapons/material/swiss.dm
+++ b/code/game/objects/items/weapons/material/swiss.dm
@@ -21,7 +21,6 @@
 
 	var/active_tool = SWISSKNF_CLOSED
 	var/tools = list(SWISSKNF_LBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER)
-	var/can_use_tools = FALSE
 	var/sharp_tools = list(SWISSKNF_LBLADE, SWISSKNF_SBLADE, SWISSKNF_GBLADE, SWISSKNF_WBLADE)
 
 /obj/item/weapon/material/knife/folding/swiss/attack_self(mob/user)
@@ -91,13 +90,13 @@
 			overlays += blood_overlay
 
 /obj/item/weapon/material/knife/folding/swiss/iscrowbar()
-	return active_tool == SWISSKNF_CROWBAR && can_use_tools
+	return active_tool == SWISSKNF_CROWBAR
 
 /obj/item/weapon/material/knife/folding/swiss/isscrewdriver()
-	return (active_tool == SWISSKNF_CLIFTER || active_tool == SWISSKNF_COPENER) && can_use_tools
+	return (active_tool == SWISSKNF_CLIFTER || active_tool == SWISSKNF_COPENER)
 
 /obj/item/weapon/material/knife/folding/swiss/iswirecutter()
-	return active_tool == SWISSKNF_WCUTTER && can_use_tools
+	return active_tool == SWISSKNF_WCUTTER
 
 /obj/item/weapon/material/knife/folding/swiss/ishatchet()
 	return active_tool == SWISSKNF_WBLADE
@@ -108,12 +107,14 @@
 		. = ..()
 		update_force()
 		return
-	if(istype(target, /obj/item))
-		if(target.w_class <= ITEM_SIZE_NORMAL)
-			can_use_tools = TRUE
-			. = ..()
-			can_use_tools = FALSE
+	if(istype(target, /obj))
+		if(active_tool == SWISSKNF_CROWBAR && !istype(target,/obj/item))
+			to_chat(user,"<span class = 'notice'>[src] doesn't provide enough leverage to do that!</span>")
 			return
+		if(active_tool in list(SWISSKNF_CROWBAR, SWISSKNF_CLIFTER, SWISSKNF_COPENER, SWISSKNF_WCUTTER, SWISSKNF_WBLADE))
+			to_chat(user,"<span class = 'notice'>You start preparing to use [src]'s [active_tool] on [target]...</span>")
+			if(!do_after(user,3 SECONDS,src))
+				return
 	return ..()
 
 /obj/item/weapon/material/knife/folding/swiss/officer

--- a/html/changelogs/embershinori-PR-331.yml
+++ b/html/changelogs/embershinori-PR-331.yml
@@ -1,0 +1,6 @@
+author: Unknown
+
+delete-after: True
+
+changes: 
+  - tweak: Added back extended combi-knife functionality from pre-rebayse.

--- a/html/changelogs/embershinori-PR-331.yml
+++ b/html/changelogs/embershinori-PR-331.yml
@@ -1,4 +1,4 @@
-author: Unknown
+author: EmberShinori
 
 delete-after: True
 


### PR DESCRIPTION
Brings back the combi-knife's extended target range so it's wirecutter and screwdrivers can be used on non-normal sized objects, such as opening an airlock's panel and then cutting the wires. Three second delay on tool use is also ported, along with the combi-knife prybar being unable to function on non-items, meaning it won't be able to pry open unpowered doors or unlocked APCs. Important note, however, is that I was unable to prevent the prybar from being able to pry up floor tiles. If that's a problem, I'll continue trying to prevent that, otherwise ready to merge. Code is also hopefully cleaner compared to pre-rebayse's code, if only slightly.

Does not port all combi-knives having all combi-knife tools, as I'm unsure if that's wanted or not. Will add if wanted, though.