### PR TITLE
Display name of airlock leading to Byahkee as "Byahkee Dock" instead of "Aquila Dock"

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -15449,7 +15449,7 @@
 "Mc" = (
 /obj/machinery/door/airlock/glass/command{
 	id_tag = null;
-	name = "Aquila Dock";
+	name = "Byahkee Dock";
 	secured_wires = 1
 	},
 /obj/machinery/door/firedoor,


### PR DESCRIPTION
The airlock in B-Deck Aft, leading to the Byahkee, shows the name "Aquila Dock". Changed that to "Bayahkee Dock".

