### PR TITLE
Adds basic gas mask to loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -150,6 +150,11 @@
 	path = /obj/item/clothing/mask/surgical
 	cost = 2
 
+/datum/gear/gas_mask
+	display_name = "basic gas mask"
+	path = /obj/item/clothing/mask/gas
+	cost = 2
+
 /datum/gear/smokingpipe
 	display_name = "pipe, smoking"
 	path = /obj/item/clothing/mask/smokable/pipe


### PR DESCRIPTION
What this does!
Adds the most basic of gas masks to the loadout!
Why?
This given that are basically every-ware means that you don't need to spend extra time on rushing to your workplace to get one if your character likes to ware them, like a mask or other cloth coverings 